### PR TITLE
feat(guarantor): 🎸 Allow going next on financial step

### DIFF
--- a/tenant/src/components/documents/GuarantorFinancial.vue
+++ b/tenant/src/components/documents/GuarantorFinancial.vue
@@ -381,6 +381,9 @@ export default class GuarantorFinancial extends Vue {
   save(f: F): boolean {
     const fieldName = "documents";
     const formData = new FormData();
+    if (f.documentType.key === undefined){
+      return true;
+    }
     if (!f.noDocument) {
       const newFiles = f.files.filter(f => {
         return !f.id;


### PR DESCRIPTION
Allow next button even when the financial document is empty (but it
won't be recorded)