### PR TITLE
add backgroudn color

### DIFF
--- a/main/src/views/LandingPage.vue
+++ b/main/src/views/LandingPage.vue
@@ -426,7 +426,7 @@ export default class LandingPage extends Vue {
   background-size: cover !important;
   background-position: 50% 50% !important;
   background-image: url("../assets/cover-features.webp");
-
+  background-color: darkgray;
   @media (max-width: 768px) {
     background-image: url("../assets/cover-features-mobile.webp");
   }


### PR DESCRIPTION
ajout d’une couleur de fond afin qu’un usager (qui aurait désactivé les images pour des questions de lenteur de connexion) puisse voir le texte blanc sur un fond foncé (au lieu d’un fond blanc par défaut ou hérité)
cf https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-3-2
Critère 3.2. Dans chaque page web, le contraste entre la couleur du texte et la couleur de son arrière-plan est-il suffisamment élevé (hors cas particuliers) ?
cf https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-10-5
Critère 10.5. Dans chaque page web, les déclarations CSS de couleurs de fond d’élément et de police sont-elles correctement utilisées ?