### PR TITLE
fix(main,tenant): Set default page name

### DIFF
--- a/main/vue.config.js
+++ b/main/vue.config.js
@@ -47,6 +47,14 @@ module.exports = {
       urls: getSitemapUrls()
     }
   },
+  chainWebpack: config => {
+        config
+            .plugin('html')
+            .tap(args => {
+                args[0].title = "DossierFacile";
+                return args;
+            })
+  },
   configureWebpack: config => {
     if (process.env.NODE_ENV !== "production") return;
 

--- a/tenant/vue.config.js
+++ b/tenant/vue.config.js
@@ -16,6 +16,14 @@ module.exports = {
       urls: ["https://locataire.dossierfacile.fr/signup"]
     }
   },
+  chainWebpack: config => {
+        config
+            .plugin('html')
+            .tap(args => {
+                args[0].title = "DossierFacile";
+                return args;
+            })
+  },
   configureWebpack: config => {
     if (process.env.NODE_ENV !== "production") return;
 


### PR DESCRIPTION
When you request page like ` https://locataire.dossierfacile.fr/account` the page title is the pakage name and if JS is disabled it shows this message 

```
We're sorry but tenant doesn't work properly without JavaScript enabled.
        Please enable it to continue.
```

This PR replace the title to `DossierFacile` (tested locally and working)