### PR TITLE
Bugfix: Remove default capitalization of first and lastname

### DIFF
--- a/owner/src/services/UtilsService.ts
+++ b/owner/src/services/UtilsService.ts
@@ -8,10 +8,6 @@ const UtilsService = {
   isMobile() {
     return window.innerWidth < 768;
   },
-  capitalize(w: string) {
-    const word = w[0].toUpperCase() + w.slice(1).toLowerCase();
-    return word.replace(/([' -][A-Za-zÀ-ÖØ-öø-ÿ])/g, (s) => s.toUpperCase());
-  },
   getAddresses(label: string) {
     return axios.get(`${API_URL}property/listAddresses/${label}`);
   },

--- a/owner/src/store/owner-store.ts
+++ b/owner/src/store/owner-store.ts
@@ -4,7 +4,6 @@ import { useCookies } from 'vue3-cookies';
 import { Composer } from 'vue-i18n';
 import { defineStore } from 'pinia';
 import { OwnerUser } from 'df-shared-next/src/models/OwnerUser';
-import UtilsService from '../services/UtilsService';
 import i18n from '../i18n';
 import AuthService from '../components/auth/AuthService';
 import keycloak from '../plugin/keycloak';
@@ -209,8 +208,8 @@ const useOwnerStore = defineStore('owner', {
     },
     saveNames(lastName: string, firstName: string, email: string) {
       return OwnerService.saveNames(
-        UtilsService.capitalize(lastName),
-        UtilsService.capitalize(firstName),
+        lastName,
+        firstName,
         email,
       )
         .then((response) => {

--- a/tenant/src/components/NameInformationForm.vue
+++ b/tenant/src/components/NameInformationForm.vue
@@ -111,7 +111,6 @@ import { AnalyticsService } from "../services/AnalyticsService";
 import ProfileFooter from "./footer/ProfileFooter.vue";
 import { mapGetters } from "vuex";
 import NakedCard from "df-shared/src/components/NakedCard.vue";
-import { UtilsService } from "@/services/UtilsService";
 import TextField from "df-shared/src/components/form/TextField.vue";
 
 extend("zipcode", {
@@ -150,7 +149,7 @@ export default class NameInformationForm extends Vue {
   beforeMount() {
     this.firstname = this.user.firstName || "";
     this.lastname = this.user.lastName || "";
-    this.preferredname = UtilsService.capitalize(this.user.preferredName || "");
+    this.preferredname = this.user.preferredName || "";
     this.zipcode = this.user.zipCode || "";
     this.displayPreferredNameField = this.preferredname !== "";
   }

--- a/tenant/src/components/documents/naturalGuarantor/GuarantorName.vue
+++ b/tenant/src/components/documents/naturalGuarantor/GuarantorName.vue
@@ -97,7 +97,6 @@ import GuarantorChoiceHelp from "../../helps/GuarantorChoiceHelp.vue";
 import VGouvFrModal from "df-shared/src/GouvFr/v-gouv-fr-modal/VGouvFrModal.vue";
 import BigRadio from "df-shared/src/Button/BigRadio.vue";
 import NakedCard from "df-shared/src/components/NakedCard.vue";
-import { UtilsService } from "../../../services/UtilsService";
 import GuarantorFooter from "../../footer/GuarantorFooter.vue";
 
 @Component({
@@ -148,10 +147,10 @@ export default class GuarantorName extends Vue {
     }
     const formData = new FormData();
     if (this.firstName) {
-      formData.append("firstName", UtilsService.capitalize(this.firstName));
+      formData.append("firstName", this.firstName);
     }
     if (this.lastName) {
-      formData.append("lastName", UtilsService.capitalize(this.lastName));
+      formData.append("lastName", this.lastName);
     }
     formData.append("guarantorId", this.$store.getters.guarantor.id);
     const loader = this.$loading.show();

--- a/tenant/src/components/documents/naturalGuarantor/TenantGuarantorName.vue
+++ b/tenant/src/components/documents/naturalGuarantor/TenantGuarantorName.vue
@@ -100,7 +100,6 @@ import GuarantorChoiceHelp from "../../helps/GuarantorChoiceHelp.vue";
 import VGouvFrModal from "df-shared/src/GouvFr/v-gouv-fr-modal/VGouvFrModal.vue";
 import BigRadio from "df-shared/src/Button/BigRadio.vue";
 import NakedCard from "df-shared/src/components/NakedCard.vue";
-import { UtilsService } from "../../../services/UtilsService";
 import GuarantorFooter from "../../footer/GuarantorFooter.vue";
 
 @Component({
@@ -148,10 +147,10 @@ export default class TenantGuarantorName extends Vue {
     }
     const formData = new FormData();
     if (this.firstName) {
-      formData.append("firstName", UtilsService.capitalize(this.firstName));
+      formData.append("firstName", this.firstName);
     }
     if (this.lastName) {
-      formData.append("lastName", UtilsService.capitalize(this.lastName));
+      formData.append("lastName", this.lastName);
     }
     if (this.guarantor.id) {
       formData.append("guarantorId", this.guarantor.id?.toString());

--- a/tenant/src/main.ts
+++ b/tenant/src/main.ts
@@ -1,4 +1,3 @@
-import { UtilsService } from "./services/UtilsService";
 import "./router/componentHooks"; // <-- Needs to be first
 import Vue from "vue";
 import App from "./App.vue";
@@ -120,9 +119,9 @@ Vue.use(VueAuthImage);
     app.$mount("#app");
 
     Vue.filter("fullName", function (user: User) {
-      const firstName = UtilsService.capitalize(user.firstName || "");
-      const lastName = UtilsService.capitalize(user.lastName || "");
-      const preferredName = UtilsService.capitalize(user.preferredName || "");
+      const firstName = user.firstName || "";
+      const lastName = user.lastName || "";
+      const preferredName = user.preferredName || "";
       return user.preferredName == null || user.preferredName.length == 0
         ? firstName + "\xa0" + lastName
         : firstName + "\xa0" + preferredName;

--- a/tenant/src/services/UtilsService.ts
+++ b/tenant/src/services/UtilsService.ts
@@ -194,13 +194,6 @@ export const UtilsService = {
   isMobile() {
     return window.innerWidth < 768;
   },
-  capitalize(word: string) {
-    if (word.length == 0) {
-      return "";
-    }
-    word = word[0].toUpperCase() + word.slice(1).toLowerCase();
-    return word.replace(/([' -][A-Za-zÀ-ÖØ-öø-ÿ])/g, (s) => s.toUpperCase());
-  },
   canShareFile(user: User) {
     return (
       user.status === "VALIDATED" &&

--- a/tenant/src/store/index.ts
+++ b/tenant/src/store/index.ts
@@ -312,15 +312,6 @@ const store = new Vuex.Store({
       );
     },
     setNames({ commit }, user: User) {
-      if (user.firstName && !user.franceConnect) {
-        user.firstName = UtilsService.capitalize(user.firstName);
-      }
-      if (user.lastName && !user.franceConnect) {
-        user.lastName = UtilsService.capitalize(user.lastName);
-      }
-      if (user.preferredName && !user.franceConnect) {
-        user.preferredName = UtilsService.capitalize(user.preferredName);
-      }
       return ProfileService.saveNames(user).then(
         (response) => {
           return commit("loadUser", response.data);

--- a/tenant/src/views/Account.vue
+++ b/tenant/src/views/Account.vue
@@ -357,7 +357,7 @@ export default class Account extends Vue {
   }
 
   getFirstName() {
-    return UtilsService.capitalize(this.user.firstName || "");
+    return this.user.firstName || "";
   }
 
   canCopyLink() {


### PR DESCRIPTION
By default, DossierFacile capitalize the first letter of each words in the firstname and the lastname. The way it's done doesn't give any way to the user to fix it as it's done when the forms are saved.

The default capitalization result to wrong case. For example my name is "de Metz". The "de" is written in lowercase. "Metz" has the first letter in uppercase. This come from previous centuries were there was "noble" people. Hopefully this system is no longer in place in France, but the way it's written persist.

There is a lot of different way to write names in the world. My proposal is to let people choose how they want to appear, without any update from the system. 