### PR TITLE
⬆️  Upgrade: bump pdfjs to 4.5.136

### DIFF
--- a/tenantv3/package.json
+++ b/tenantv3/package.json
@@ -32,7 +32,7 @@
     "df-shared-next": "0.1.0",
     "js-cookie": "3.0.5",
     "keycloak-js": "25.0.6",
-    "pdfjs-dist": "4.2.67",
+    "pdfjs-dist": "4.5.136",
     "pinia": "2.2.2",
     "vee-validate": "4.12.2",
     "vue": "3.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6915,7 +6915,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-path2d@^0.2.0:
+path2d@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/path2d/-/path2d-0.2.2.tgz#cc85d61ed7827e7863a2ee36713d4b5315a3d85d"
   integrity sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==
@@ -6937,13 +6937,13 @@ pause-stream@0.0.11:
   dependencies:
     through "~2.3"
 
-pdfjs-dist@4.2.67:
-  version "4.2.67"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-4.2.67.tgz#dd2a65a4b00d95cd4bc2c1f6a27c5e9eb31d512a"
-  integrity sha512-rJmuBDFpD7cqC8WIkQUEClyB4UAH05K4AsyewToMTp2gSy3Rrx8c1ydAVqlJlGv3yZSOrhEERQU/4ScQQFlLHA==
+pdfjs-dist@4.5.136:
+  version "4.5.136"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-4.5.136.tgz#4c6f67252d4e23212f43b36537a142171ebfb1ca"
+  integrity sha512-V1BALcAN/FmxBEShLxoP73PlQZAZtzlaNfRbRhJrKvXzjLC5VaIlBAQUJuWP8iaYUmIdmdLHmt3E2TBglxOm3w==
   optionalDependencies:
     canvas "^2.11.2"
-    path2d "^0.2.0"
+    path2d "^0.2.1"
 
 pend@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Be careful if you want to update to latest version, we may need polyfill for old safaris