### PR TITLE
🐛 Fix(tenant): outdated id in URL after delete

### DIFF
--- a/tenantv3/src/__tests__/updateFinancialURL.spec.ts
+++ b/tenantv3/src/__tests__/updateFinancialURL.spec.ts
@@ -1,0 +1,17 @@
+import { updateFinancialURL } from '../components/financial/lib/updateFinancialUrl'
+import { describe, it, expect } from 'vitest'
+
+describe('updateFinancialURL', () => {
+  it('replace id in URL', () => {
+    const url = updateFinancialURL('/documents-locataire/4/855/travail/salarie/plus-3-mois', 855)
+    expect(url).to.eq('/documents-locataire/4/ajouter/travail/salarie/plus-3-mois')
+  })
+  it('replace final id in URL', () => {
+    const url = updateFinancialURL('/documents-locataire/4/855', 855)
+    expect(url).to.eq('/documents-locataire/4/ajouter')
+  })
+  it('replace id in URL for spouse', () => {
+    const url = updateFinancialURL('/documents-colocataire/273/4/4/856/social/caf/plus-3-mois', 856)
+    expect(url).to.eq('/documents-colocataire/273/4/4/ajouter/social/caf/plus-3-mois')
+  })
+})

--- a/tenantv3/src/components/financial/lib/FinancialBackRow.vue
+++ b/tenantv3/src/components/financial/lib/FinancialBackRow.vue
@@ -31,6 +31,7 @@ import BackLinkRow from '@/components/common/BackLinkRow.vue'
 import { useI18n } from 'vue-i18n'
 import { useFinancialState } from '../financialState'
 import { AnalyticsService } from '@/services/AnalyticsService'
+import { updateFinancialURL } from './updateFinancialUrl'
 
 const props = defineProps<{
   label: string
@@ -75,7 +76,7 @@ const confirm = async () => {
   if (docId) {
     await store.deleteDocument(docId)
   }
-  const to = typeof props.to === 'string' ? props.to.replace(`/${docId}/`, '/ajouter/') : props.to
+  const to = typeof props.to === 'string' ? updateFinancialURL(props.to, docId) : props.to
   router.push(to)
 }
 

--- a/tenantv3/src/components/financial/lib/updateFinancialUrl.ts
+++ b/tenantv3/src/components/financial/lib/updateFinancialUrl.ts
@@ -1,0 +1,2 @@
+export const updateFinancialURL = (url: string, docId: number | undefined) =>
+  url.replace(`/${docId}/`, '/ajouter/').replace(new RegExp(`/${docId}$`), '/ajouter')


### PR DESCRIPTION
This would cause duplicated documents if a file was uploaded afterwards