### PR TITLE
🐛 Fix(tenant): Guarantor with no name

### DIFF
--- a/tenantv3/src/stores/tenant-store.ts
+++ b/tenantv3/src/stores/tenant-store.ts
@@ -684,6 +684,9 @@ export const useTenantStore = defineStore('tenant', {
       }
       if (this.user.guarantors) {
         for (const g of this.user.guarantors) {
+          if (g.typeGuarantor === 'NATURAL_PERSON' && (!g.firstName || !g.lastName)) {
+            return this.setGuarantorPage(g, 0)
+          }
           if (!UtilsService.guarantorHasDoc('IDENTIFICATION', g)) {
             return this.setGuarantorPage(g, 1)
           }


### PR DESCRIPTION
If a user creates a Guarantor but does not fill its name and firstname, on their next login the GuarantorName step would be skipped. This would result in a Guarantor with no name and firstname.