### PR TITLE
🩹 Fix(owner): Disable email change

### DIFF
--- a/owner/src/components/account/NameInformationForm.vue
+++ b/owner/src/components/account/NameInformationForm.vue
@@ -80,6 +80,7 @@
               >
                 <input
                   v-bind="field"
+                  disabled
                   class="validate-required form-control fr-input"
                   :class="{
                     'fr-input--valid': meta.valid,


### PR DESCRIPTION
The email change does not update the account in keycloak, causing owners who change email to be unable to login