### PR TITLE
Fix: vertically center :before icons on FeedbackComponent buttons

### DIFF
--- a/watermark/src/components/FeedbackComponent.vue
+++ b/watermark/src/components/FeedbackComponent.vue
@@ -79,9 +79,12 @@ function dislike() {
 }
 
 .like {
+  display: inline-flex;
+  align-items: center;
   background-color: rgb(184, 254, 201);
   color: rgb(24, 117, 60);
   padding: 0.5rem;
+  margin-top: 1rem;
   margin-right: 1rem;
   &:before {
     content: "";
@@ -95,6 +98,8 @@ function dislike() {
 }
 
 .dislike {
+  display: inline-flex;
+  align-items: center;
   background-color: #ffe9e6;
   color: #9c0400;
   padding: 0.5rem;


### PR DESCRIPTION
### Description 

The `:before icons` of the **"like"** and **"dislike"** buttons in the **FeedbackComponent** were not vertically centered.

This PR adds a `display: inline-flex` and `align-items: center` to both buttons to fix this minor visual issue.

### Screenshots

**Before**
<img width="428" height="49" alt="before" src="https://github.com/user-attachments/assets/b59401d0-f34e-4e4c-b663-912422d0e80f" />

**After**
<img width="430" height="54" alt="after" src="https://github.com/user-attachments/assets/2b4ea70b-06f8-4c79-b662-ec02b4d66643" />

### Type of change
- [x] Bug fix (non-breaking change which fixes a visual issue)