### PR TITLE
fix: remove horizontal scroll on file page

### DIFF
--- a/tenantv3/src/components/OwnerBanner.vue
+++ b/tenantv3/src/components/OwnerBanner.vue
@@ -61,10 +61,6 @@ const OWNER_URL = `//${import.meta.env.VITE_OWNER_URL}/creation`
 
 .wrapper {
   overflow: hidden;
-  margin-left: -30px;
-  padding-left: 30px;
-  margin-right: -30px;
-  padding-right: 30px;
 }
 
 .men {


### PR DESCRIPTION

<img width="410" height="810" alt="Screenshot 2025-12-17 at 10 21 00" src="https://github.com/user-attachments/assets/10748416-9663-4dc1-a003-a8c3a6230e22" />
<img width="501" height="810" alt="Screenshot 2025-12-17 at 10 21 13" src="https://github.com/user-attachments/assets/d49e93b9-1eb6-4039-9f91-005b3ed5a352" />

Removes negative margins and padding on the wrapper class in the owner banner component.

This prevents unintended horizontal scrolling on the file page, improving user experience.