### PR TITLE
fix(owner): improve error handling for account confirmation

### DIFF
--- a/owner/src/components/account/ConfirmAccountPage.vue
+++ b/owner/src/components/account/ConfirmAccountPage.vue
@@ -1,29 +1,68 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import AuthService from '../auth/AuthService'
+import axios from 'axios'
 
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 
 const token = route.params.token.toString()
-const showError = ref(false)
+type ErrorType = 'loading' | 'link-invalid' | 'server-error' | 'generic'
+const errorType = ref<ErrorType>('loading')
 
-AuthService.confirmAccount(token).then(
-  () => {
+onMounted(async () => {
+  try {
+    await AuthService.confirmAccount(token)
     router.push({ name: 'Dashboard' })
-  },
-  () => {
-    showError.value = true
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const status = error.response.status
+      if (status === 404) {
+        errorType.value = 'link-invalid'
+      } else if (status >= 500) {
+        errorType.value = 'server-error'
+      } else {
+        errorType.value = 'generic'
+      }
+    } else {
+      errorType.value = 'generic'
+    }
   }
-)
+})
 </script>
 
 <template>
-  <div class="fr-container">
-    <div v-if="!showError">{{ t('confirmaccountpage.loading') }}</div>
-    <div v-if="showError">{{ t('confirmaccountpage.error-occured') }}</div>
+  <div class="fr-container fr-py-4w">
+    <div v-if="errorType === 'loading'">{{ t('confirmaccountpage.loading') }}</div>
+    <div v-else-if="errorType === 'link-invalid'" class="fr-alert fr-alert--warning">
+      <h3 class="fr-alert__title">{{ t('confirmaccountpage.link-invalid-title') }}</h3>
+      <p>{{ t('confirmaccountpage.link-invalid') }}</p>
+      <ul class="fr-mt-1w fr-mb-2w">
+        <li>{{ t('confirmaccountpage.link-invalid-reason-1') }}</li>
+        <li>{{ t('confirmaccountpage.link-invalid-reason-2') }}</li>
+      </ul>
+      <p>{{ t('confirmaccountpage.link-invalid-hint') }}</p>
+      <p class="fr-mt-2w">
+        <router-link :to="{ name: 'Dashboard' }" class="fr-btn fr-btn--secondary">
+          {{ t('confirmaccountpage.go-to-login') }}
+        </router-link>
+      </p>
+    </div>
+    <div v-else-if="errorType === 'server-error'" class="fr-alert fr-alert--error">
+      <h3 class="fr-alert__title">{{ t('confirmaccountpage.server-error-title') }}</h3>
+      <p>{{ t('confirmaccountpage.server-error') }}</p>
+      <p class="fr-mt-2w">
+        <a href="/contact" class="fr-link">
+          {{ t('confirmaccountpage.contact-support') }}
+        </a>
+      </p>
+    </div>
+    <div v-else class="fr-alert fr-alert--error">
+      <h3 class="fr-alert__title">{{ t('confirmaccountpage.error-title') }}</h3>
+      <p>{{ t('confirmaccountpage.error-occured') }}</p>
+    </div>
   </div>
 </template>

--- a/owner/src/locales/en.json
+++ b/owner/src/locales/en.json
@@ -37,7 +37,17 @@
   },
   "confirmaccountpage": {
     "loading": "Please wait",
-    "error-occured": "An error occurred"
+    "error-title": "Error",
+    "error-occured": "An error occurred. Please try again later.",
+    "link-invalid-title": "Invalid or already used link",
+    "link-invalid": "This confirmation link is not valid. This can happen if:",
+    "link-invalid-reason-1": "The link has already been used to confirm your account",
+    "link-invalid-reason-2": "The link is incorrect or incomplete",
+    "link-invalid-hint": "If you have already confirmed your account, you can log in directly.",
+    "go-to-login": "Log in",
+    "server-error-title": "Server error",
+    "server-error": "A technical error occurred. Please try again later or contact DossierFacile support if the problem persists.",
+    "contact-support": "Contact DossierFacile support"
   },
   "connectproperty": {
     "title": "Consultation",

--- a/owner/src/locales/fr.json
+++ b/owner/src/locales/fr.json
@@ -43,7 +43,17 @@
   },
   "confirmaccountpage": {
     "loading": "Veuillez patienter",
-    "error-occured": "Une erreur est survenue"
+    "error-title": "Erreur",
+    "error-occured": "Une erreur est survenue. Veuillez réessayer plus tard.",
+    "link-invalid-title": "Lien invalide ou déjà utilisé",
+    "link-invalid": "Ce lien de confirmation n'est pas valide. Cela peut se produire si :",
+    "link-invalid-reason-1": "Le lien a déjà été utilisé pour confirmer votre compte",
+    "link-invalid-reason-2": "Le lien est incorrect ou incomplet",
+    "link-invalid-hint": "Si vous avez déjà confirmé votre compte, vous pouvez vous connecter directement.",
+    "go-to-login": "Se connecter",
+    "server-error-title": "Erreur serveur",
+    "server-error": "Une erreur technique est survenue. Veuillez réessayer plus tard ou contacter le support DossierFacile si le problème persiste.",
+    "contact-support": "Contacter le support DossierFacile"
   },
   "connectproperty": {
     "title": "Consultation",


### PR DESCRIPTION
En lien avec le thread : https://mattermost.incubateur.net/dossierfacile/pl/cy71xzq9dpyhtdt5yx6z4wemzy

- Handle 404 status with specific message for invalid/used links
- Handle 500 status with server error message and support contact

<img width="645" height="1001" alt="Screenshot 2025-12-30 at 11 56 06" src="https://github.com/user-attachments/assets/72704f7c-ad8a-4af9-8ef8-b11ff26975ec" />
<img width="645" height="1002" alt="Screenshot 2025-12-30 at 11 56 20" src="https://github.com/user-attachments/assets/41d6cc43-0bb9-4616-a4e0-2b60b0f64e3f" />
