### PR TITLE
Fix: Document IA QA small fixes

### DIFF
--- a/tenantv3/src/components/tax/lib/TaxAnalysisBanners.vue
+++ b/tenantv3/src/components/tax/lib/TaxAnalysisBanners.vue
@@ -76,7 +76,7 @@ function getCurrentDocLines(rule: DocumentRule): string[] {
     case 'R_NAMES':
       return data.extractedNames.map((n) => t('rules.names.current', { name: formatName(n) }))
     case 'R_TAX_YEARS':
-      return data.extractedYears.map((y) => t('rules.wrong-year.current', { year: y, yearMinusOne: y - 1 }))
+      return data.extractedYears.map((y) => t('rules.wrong-year.current', { taxYear: y + 1, incomeYear: y }))
     default:
       return [rule.message]
   }
@@ -93,7 +93,7 @@ function getExpectedDocLines(rule: DocumentRule): string[] {
     case 'R_NAMES':
       return [t('rules.names.expected', { name: formatName(data.expectedName) })]
     case 'R_TAX_YEARS':
-      return [t('rules.wrong-year.expected', { year: data.expectedYear, yearMinusOne: data.expectedYear - 1 })]
+      return [t('rules.wrong-year.expected', { taxYear: data.expectedYear + 1 , incomeYear: data.expectedYear})]
     default:
       return [rule.message]
   }
@@ -226,8 +226,8 @@ function getExpectedDocLines(rule: DocumentRule): string[] {
       },
       "wrong-year": {
         "title": "Tax notice too old",
-        "current": "Tax notice {year} on {yearMinusOne} income",
-        "expected": "Tax notice {year} on {yearMinusOne} income or non-taxation notice"
+        "current": "Tax notice {taxYear} on {incomeYear} income",
+        "expected": "Tax notice {taxYear} on {incomeYear} income or non-taxation notice"
       },
       "invalid-2ddoc": {
         "title": "Invalid document"
@@ -253,8 +253,8 @@ function getExpectedDocLines(rule: DocumentRule): string[] {
       },
       "wrong-year": {
         "title": "Avis d'imposition trop ancien",
-        "current": "Avis d'imposition {year} sur revenus {yearMinusOne}",
-        "expected": "Avis d'imposition {year} sur revenus {yearMinusOne} ou avis de non-imposition"
+        "current": "Avis d'imposition {taxYear} sur revenus {incomeYear}",
+        "expected": "Avis d'imposition {taxYear} sur revenus {incomeYear} ou avis de non-imposition"
       },
       "invalid-2ddoc": {
         "title": "Document invalide"

--- a/tenantv3/src/components/tax/lib/UploadFilesTax.vue
+++ b/tenantv3/src/components/tax/lib/UploadFilesTax.vue
@@ -20,7 +20,7 @@
   </div>
   <div v-if="analysisInProgress" class="analysis-loading fr-mb-3w">
     <div class="analysis-loading-status">
-      <RiContractUpDownLine size="24px" class="analysis-loading-icon" aria-hidden="true" />
+      <RiHourglassFill size="24px" class="analysis-loading-icon" aria-hidden="true" />
       <p class="fr-m-0 analysis-loading-text">{{ t('analysis-in-progress') }}</p>
     </div>
     <div class="analysis-loading-progress">
@@ -116,7 +116,7 @@ import type { TaxCategory } from '@/components/documents/share/DocumentTypeConst
 import type { TaxCategoryStep } from 'df-shared-next/src/models/DfDocument'
 import { PdfAnalysisService } from '@/services/PdfAnalysisService'
 import ModalComponent from 'df-shared-next/src/components/ModalComponent.vue'
-import { RiAlarmWarningLine, RiContractUpDownLine, RiInformationFill } from '@remixicon/vue'
+import { RiAlarmWarningLine, RiHourglassFill, RiInformationFill } from '@remixicon/vue'
 import DfButton from 'df-shared-next/src/Button/DfButton.vue'
 import TaxAnalysisBanners from './TaxAnalysisBanners.vue'
 
@@ -200,6 +200,7 @@ onMounted(() => {
   const existingComment = taxDocument.value?.documentAnalysisReport?.comment || ''
   explainText.value = existingComment
   explanationSubmitted.value = !!existingComment
+  showExplainForm.value = !!existingComment
   startPolling()
 })
 


### PR DESCRIPTION
Sur la page d'avis d'imposition avec analyse document ia
- correction de l'icone de loading
- l'explication pour bypass les erreurs d'analyse est toujours visible après la première explication
- fix sur le message R_TAX_WRONG_YEAR