### PR TITLE
feat : handle new authentified endpoint for documents 

### DIFF
--- a/tenantv3/src/components/__tests__/FileRowListItem.spec.ts
+++ b/tenantv3/src/components/__tests__/FileRowListItem.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FileRowListItem from '../documents/FileRowListItem.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@/components/toast/toastUtils', () => ({
+  toast: { error: vi.fn() }
+}))
+
+vi.mock('@/services/UtilsService', () => ({
+  UtilsService: {
+    getFileNameFromHeaders: vi.fn(() => 'document.pdf')
+  }
+}))
+
+vi.mock('@/services/ApiService', () => ({
+  apiService: {
+    get: vi.fn(),
+    interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } }
+  }
+}))
+
+describe('FileRowListItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a direct link for unauthenticated link URL ', () => {
+    const wrapper = mount(FileRowListItem, {
+      global: { stubs: { RouterLink: true } },
+      props: {
+        label: 'Identification',
+        enableDownload: true,
+        document: {
+          documentStatus: 'VALIDATED',
+          name: 'https://api.example.com/api/application/links/abc-123/documents/doc-uuid'
+        }
+      }
+    })
+    const link = wrapper.find(
+      'a[href="https://api.example.com/api/application/links/abc-123/documents/doc-uuid"]'
+    )
+    expect(link.exists()).toBe(true)
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('renders a button for authenticated direct document URL', () => {
+    const wrapper = mount(FileRowListItem, {
+      global: { stubs: { RouterLink: true } },
+      props: {
+        label: 'Identification',
+        enableDownload: true,
+        document: {
+          documentStatus: 'VALIDATED',
+          name: 'https://api.example.com/api/document/resource/doc-uuid'
+        }
+      }
+    })
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.attributes('type')).toBe('button')
+    expect(wrapper.find('a[href*="document/resource"]').exists()).toBe(false)
+  })
+})

--- a/tenantv3/src/locales/en.json
+++ b/tenantv3/src/locales/en.json
@@ -421,7 +421,9 @@
   "filerowlistitem": {
     "edit": "Update",
     "see": "See",
-    "see-title": "See - Open in a new window"
+    "see-title": "See - Open in a new window",
+    "view-failed": "Unable to open the document. Please try again.",
+    "download": "Download"
   },
   "fileupload": {
     "drag-and-drop-files": "Drag and drop your documents:",

--- a/tenantv3/src/locales/fr.json
+++ b/tenantv3/src/locales/fr.json
@@ -423,7 +423,9 @@
   "filerowlistitem": {
     "edit": "Mettre à jour",
     "see": "Voir",
-    "see-title": "Voir - Ouvre une nouvelle fenêtre"
+    "see-title": "Voir - Ouvre une nouvelle fenêtre",
+    "view-failed": "Impossible d'ouvrir le document. Veuillez réessayer.",
+    "download": "Télécharger"
   },
   "fileupload": {
     "drag-and-drop-files": "Glissez et déposez vos documents :",


### PR DESCRIPTION
GET /api/document/resource/{uuid} est maintenant authentifié. 
Le front envoie donc une requête authentifiée au back pour charger le fichier en mémoire et le render