### PR TITLE
feat(a11y): keep next button enabled on tax upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pnpm-debug.log*
 
 **/cypress/screenshots
 **/cypress/videos
+.cursor/rules/test-language.mdc

--- a/e2e-tests/cypress/e2e/tenant/tax-analysis.cy.ts
+++ b/e2e-tests/cypress/e2e/tenant/tax-analysis.cy.ts
@@ -39,14 +39,28 @@ describe("tax document analysis", () => {
     cy.get(".analysis-banners", { timeout: 15000 }).should("exist");
     cy.get(".analysis-banners").should("have.focus");
     cy.get(".analysis-banner").should("have.length.at.least", 1);
-    cy.get('[data-cy="next-btn"]').should("be.disabled");
+
+    cy.get('[data-cy="next-btn"]').should("not.be.disabled");
+    cy.get('[data-cy="next-btn"]').click();
+    cy.get(".analysis-banners").should("have.focus");
+    cy.url().should("include", "avec-avis/francais");
 
     cy.get(".explain-link").first().click();
     cy.get("#explainText").should("exist").and("have.focus");
-    cy.get("#explainText").type("test");
+
+    cy.get(".explain-form-actions").contains("Enregistrer").should("not.be.disabled");
     cy.get(".explain-form-actions").contains("Enregistrer").click();
+    cy.get(".fr-error-text").should("be.visible");
+    cy.get("#explainText").should("have.focus");
+
+    cy.get("#explainText").type("test");
+    cy.get(".fr-error-text").should("be.visible");
+
+    cy.get(".explain-form-actions").contains("Enregistrer").click();
+    cy.get(".fr-error-text").should("not.exist");
     cy.contains("Votre explication a bien été enregistrée").should("be.visible");
 
-    cy.get('[data-cy="next-btn"]').should("not.be.disabled");
+    cy.get('[data-cy="next-btn"]').click();
+    cy.url().should("not.include", "avec-avis/francais");
   });
 });

--- a/tenantv3/src/components/__tests__/FrenchTaxForm.spec.ts
+++ b/tenantv3/src/components/__tests__/FrenchTaxForm.spec.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, ref } from 'vue'
+import FrenchTaxForm from '../tax/FrenchTaxForm.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  }),
+  createI18n: () => ({
+    global: { t: (key: string) => key }
+  })
+}))
+
+vi.mock('@/components/common/lib/useParentRoute', () => ({
+  useParentRoute: () => ref('/')
+}))
+
+vi.mock('../tax/lib/taxYear', () => ({
+  taxYear: 2025
+}))
+
+vi.mock('../tax/lib/taxState', () => ({
+  useTaxState: () => ({
+    previousStep: '/',
+    nextStep: '/next',
+    document: ref(undefined),
+    category: 'tax' as const,
+    textKey: 'tenant' as const,
+    userId: 123,
+    action: 'saveTenantTax' as const
+  })
+}))
+
+const mockAnalysisFailedRules = ref<unknown[]>([])
+const mockExplanationSubmitted = ref(false)
+const mockAnalysisInProgress = ref(false)
+const mockIsUploading = ref(false)
+const mockOpenExplainSection = vi.fn()
+
+const FakeUploadFilesTax = defineComponent({
+  name: 'UploadFilesTax',
+  setup(_, { expose }) {
+    expose({
+      analysisFailedRules: mockAnalysisFailedRules,
+      explanationSubmitted: mockExplanationSubmitted,
+      analysisInProgress: mockAnalysisInProgress,
+      isUploading: mockIsUploading,
+      openExplainSection: mockOpenExplainSection
+    })
+    return () => null
+  }
+})
+
+const mockBannersFocus = vi.fn()
+
+const FakeTaxAnalysisBanners = defineComponent({
+  name: 'TaxAnalysisBanners',
+  props: { failedRules: { type: Array, default: () => [] } },
+  setup(_, { expose }) {
+    expose({ focus: mockBannersFocus })
+    return () => null
+  }
+})
+
+const globalStubs = {
+  BackLinkRow: true,
+  TaxFooter: true,
+  DfButton: true,
+  DsfrAlert: true,
+  VIcon: true,
+  ModalComponent: true,
+  'i18n-t': true
+}
+
+function mountComponent() {
+  return mount(FrenchTaxForm, {
+    global: {
+      stubs: {
+        ...globalStubs,
+        UploadFilesTax: FakeUploadFilesTax,
+        TaxAnalysisBanners: FakeTaxAnalysisBanners
+      }
+    }
+  })
+}
+
+function getTaxFooterProps(wrapper: ReturnType<typeof mountComponent>) {
+  const taxFooter = wrapper.findComponent({ name: 'TaxFooter' })
+  return taxFooter.props() as {
+    nextDisabled?: boolean
+    nextLabel?: string
+    beforeSubmit?: () => boolean
+  }
+}
+
+describe('FrenchTaxForm - Continue button states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAnalysisFailedRules.value = []
+    mockExplanationSubmitted.value = false
+    mockAnalysisInProgress.value = false
+    mockIsUploading.value = false
+  })
+
+  it('uploading: nextLabel = uploading, nextDisabled = true, beforeSubmit blocks', async () => {
+    mockIsUploading.value = true
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const props = getTaxFooterProps(wrapper)
+    expect(props.nextDisabled).toBe(true)
+    expect(props.nextLabel).toBe('uploading')
+    expect(props.beforeSubmit).toBeDefined()
+    expect(props.beforeSubmit()).toBe(false)
+    expect(mockBannersFocus).not.toHaveBeenCalled()
+  })
+
+  it('analysis in progress: nextLabel = analyzing, nextDisabled = true, beforeSubmit blocks', async () => {
+    mockAnalysisInProgress.value = true
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const props = getTaxFooterProps(wrapper)
+    expect(props.nextDisabled).toBe(true)
+    expect(props.nextLabel).toBe('analyzing')
+    expect(props.beforeSubmit).toBeDefined()
+    expect(props.beforeSubmit()).toBe(false)
+    expect(mockBannersFocus).not.toHaveBeenCalled()
+  })
+
+  it('unresolved errors: nextDisabled = false, beforeSubmit focuses banners and blocks', async () => {
+    mockAnalysisFailedRules.value = [
+      { rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }
+    ]
+    mockExplanationSubmitted.value = false
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const props = getTaxFooterProps(wrapper)
+    expect(props.nextDisabled).toBe(false)
+    expect(props.nextLabel).toBeUndefined()
+    expect(props.beforeSubmit).toBeDefined()
+    expect(props.beforeSubmit()).toBe(false)
+    expect(mockBannersFocus).toHaveBeenCalledOnce()
+  })
+
+  it('ready (no errors): nextDisabled = false, beforeSubmit allows submit', async () => {
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const props = getTaxFooterProps(wrapper)
+    expect(props.nextDisabled).toBe(false)
+    expect(props.nextLabel).toBeUndefined()
+    expect(props.beforeSubmit).toBeDefined()
+    expect(props.beforeSubmit()).toBe(true)
+    expect(mockBannersFocus).not.toHaveBeenCalled()
+  })
+
+  it('ready (errors with explanation submitted): nextDisabled = false, beforeSubmit allows submit', async () => {
+    mockAnalysisFailedRules.value = [
+      { rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }
+    ]
+    mockExplanationSubmitted.value = true
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const props = getTaxFooterProps(wrapper)
+    expect(props.nextDisabled).toBe(false)
+    expect(props.nextLabel).toBeUndefined()
+    expect(props.beforeSubmit).toBeDefined()
+    expect(props.beforeSubmit()).toBe(true)
+    expect(mockBannersFocus).not.toHaveBeenCalled()
+  })
+})

--- a/tenantv3/src/components/__tests__/UploadFilesTax.spec.ts
+++ b/tenantv3/src/components/__tests__/UploadFilesTax.spec.ts
@@ -156,8 +156,8 @@ describe('UploadFilesTax', () => {
     vi.useRealTimers()
   })
 
-  describe('Polling - démarrage au mount', () => {
-    it('appelle getDocumentAnalysisStatus au montage', async () => {
+  describe('Polling - start on mount', () => {
+    it('calls getDocumentAnalysisStatus on mount', async () => {
       mockAnalysisResponse(AnalysisStatus.NO_ANALYSIS_SCHEDULED)
       mountComponent()
       await flushPromises()
@@ -166,8 +166,8 @@ describe('UploadFilesTax', () => {
     })
   })
 
-  describe('Polling - arrêt quand COMPLETED', () => {
-    it('arrête le polling et remplit analysisFailedRules', async () => {
+  describe('Polling - stops when COMPLETED', () => {
+    it('stops polling and populates analysisFailedRules', async () => {
       const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
       mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
 
@@ -178,15 +178,15 @@ describe('UploadFilesTax', () => {
       expect(wrapper.vm.analysisFailedRules).toEqual(rules)
       expect(wrapper.vm.analysisInProgress).toBe(false)
 
-      // Avancer le temps : pas de nouvel appel (polling arrêté)
+      // Fast-forward time: no new call (polling stopped)
       await vi.advanceTimersByTimeAsync(6000)
       await flushPromises()
       expect(AnalysisService.getDocumentAnalysisStatus).toHaveBeenCalledTimes(1)
     })
   })
 
-  describe('Polling - arrêt quand NO_ANALYSIS_SCHEDULED', () => {
-    it('arrête le polling et met analysisInProgress à false', async () => {
+  describe('Polling - stops when NO_ANALYSIS_SCHEDULED', () => {
+    it('stops polling and sets analysisInProgress to false', async () => {
       mockAnalysisResponse(AnalysisStatus.NO_ANALYSIS_SCHEDULED)
 
       const wrapper = mountComponent()
@@ -195,15 +195,15 @@ describe('UploadFilesTax', () => {
       expect(wrapper.vm.analysisInProgress).toBe(false)
       expect(wrapper.vm.analysisFailedRules).toEqual([])
 
-      // Avancer le temps : pas de nouvel appel
+      // Fast-forward time: no new call
       await vi.advanceTimersByTimeAsync(6000)
       await flushPromises()
       expect(AnalysisService.getDocumentAnalysisStatus).toHaveBeenCalledTimes(1)
     })
   })
 
-  describe('Polling - timeout après POLLING_TIMEOUT_MS', () => {
-    it('arrête le polling après le timeout même si IN_PROGRESS', async () => {
+  describe('Polling - timeout after POLLING_TIMEOUT_MS', () => {
+    it('stops polling after timeout even if IN_PROGRESS', async () => {
       mockAnalysisResponse(AnalysisStatus.IN_PROGRESS)
 
       const wrapper = mountComponent()
@@ -211,13 +211,13 @@ describe('UploadFilesTax', () => {
 
       expect(wrapper.vm.analysisInProgress).toBe(true)
 
-      // Avancer au-delà du timeout (10s)
+      // Fast-forward beyond timeout (10s)
       await vi.advanceTimersByTimeAsync(11000)
       await flushPromises()
 
       expect(wrapper.vm.analysisInProgress).toBe(false)
 
-      // Vérifier que le polling ne continue plus
+      // Verify polling no longer continues
       const callCount = vi.mocked(AnalysisService.getDocumentAnalysisStatus).mock.calls.length
       await vi.advanceTimersByTimeAsync(6000)
       await flushPromises()
@@ -225,23 +225,23 @@ describe('UploadFilesTax', () => {
     })
   })
 
-  describe('Polling - continue tant que IN_PROGRESS', () => {
-    it('continue à appeler le service toutes les 3s', async () => {
+  describe('Polling - continues while IN_PROGRESS', () => {
+    it('keeps calling the service every 3s', async () => {
       mockAnalysisResponse(AnalysisStatus.IN_PROGRESS)
 
       const wrapper = mountComponent()
       await flushPromises()
 
-      // Appel initial au mount
+      // Initial call on mount
       expect(AnalysisService.getDocumentAnalysisStatus).toHaveBeenCalledTimes(1)
       expect(wrapper.vm.analysisInProgress).toBe(true)
 
-      // Avancer de 3s → 2e appel
+      // Fast-forward 3s -> 2nd call
       await vi.advanceTimersByTimeAsync(3000)
       await flushPromises()
       expect(AnalysisService.getDocumentAnalysisStatus).toHaveBeenCalledTimes(2)
 
-      // Avancer de 3s → 3e appel
+      // Fast-forward 3s -> 3rd call
       await vi.advanceTimersByTimeAsync(3000)
       await flushPromises()
       expect(AnalysisService.getDocumentAnalysisStatus).toHaveBeenCalledTimes(3)
@@ -250,10 +250,9 @@ describe('UploadFilesTax', () => {
     })
   })
 
-
-  describe('Suppression - reset de l\'état d\'analyse', () => {
-    it('réinitialise analysisInProgress, analysisFailedRules et explainText', async () => {
-      // D'abord monter avec COMPLETED + failedRules
+  describe('Deletion - resets analysis state', () => {
+    it('resets analysisInProgress, analysisFailedRules and explainText', async () => {
+      // First mount with COMPLETED + failedRules
       const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
       mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
 
@@ -262,11 +261,10 @@ describe('UploadFilesTax', () => {
 
       expect(wrapper.vm.analysisFailedRules).toEqual(rules)
 
-      // Préparer le mock pour le polling qui redémarre après remove
+      // Prepare mock for polling restart after remove
       mockAnalysisResponse(AnalysisStatus.NO_ANALYSIS_SCHEDULED)
 
-      // Simuler un remove via l'événement du ListItem
-      // On accède directement à la fonction expose n'est pas suffisant, on appelle remove via le composant
+      // Simulate remove via the component's internal function
       const file = { id: 1, name: 'tax.pdf', size: 1000 }
       await wrapper.vm.$.setupState.remove(file)
       await flushPromises()
@@ -277,15 +275,15 @@ describe('UploadFilesTax', () => {
     })
   })
 
-  describe('Explication - sauvegarde du commentaire', () => {
-    it('appelle commentAnalysis avec les bons paramètres', async () => {
+  describe('Explanation - save comment', () => {
+    it('calls commentAnalysis with correct parameters', async () => {
       const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
       mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
 
       const wrapper = mountComponent()
       await flushPromises()
 
-      // Accéder à saveExplanation via le setup state interne
+      // Access saveExplanation via internal setup state
       // setupState auto-unwraps refs, so assign directly without .value
       wrapper.vm.$.setupState.explainText = 'Mon explication'
       wrapper.vm.$.setupState.saveExplanation()
@@ -297,6 +295,36 @@ describe('UploadFilesTax', () => {
         comment: 'Mon explication'
       })
       expect(wrapper.vm.explanationSubmitted).toBe(true)
+    })
+
+    it('shows error and does not call API when explanation is empty', async () => {
+      const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
+      mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      wrapper.vm.$.setupState.explainText = ''
+      wrapper.vm.$.setupState.saveExplanation()
+      await flushPromises()
+
+      expect(mockCommentAnalysis).not.toHaveBeenCalled()
+      expect(wrapper.vm.$.setupState.showExplainError).toBe(true)
+    })
+
+    it('shows error and does not call API when explanation is whitespace only', async () => {
+      const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
+      mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      wrapper.vm.$.setupState.explainText = '   '
+      wrapper.vm.$.setupState.saveExplanation()
+      await flushPromises()
+
+      expect(mockCommentAnalysis).not.toHaveBeenCalled()
+      expect(wrapper.vm.$.setupState.showExplainError).toBe(true)
     })
   })
 })

--- a/tenantv3/src/components/tax/FrenchTaxForm.vue
+++ b/tenantv3/src/components/tax/FrenchTaxForm.vue
@@ -63,8 +63,8 @@
     </template>
   </ModalComponent>
 
-  <UploadFilesTax ref="upload-files-tax" category="MY_NAME" step="TAX_FRENCH_NOTICE" :show-pre-validation="false" @analysis-error="focusBanners" />
-  <TaxFooter :next-disabled="nextDisabled" />
+  <UploadFilesTax ref="upload-files-tax" category="MY_NAME" step="TAX_FRENCH_NOTICE" :show-pre-validation="false"@analysis-error="focusBanners" />
+  <TaxFooter :next-disabled="nextDisabled" :next-label="nextLabel" :before-submit="beforeSubmit" />
 </template>
 
 <script setup lang="ts">
@@ -93,7 +93,28 @@ const uploadFilesTax = useTemplateRef('upload-files-tax')
 const taxBanners = useTemplateRef('tax-banners')
 const analysisErrorCount = computed(() => uploadFilesTax.value?.analysisFailedRules?.length ?? 0)
 const analysisInProgress = computed(() => uploadFilesTax.value?.analysisInProgress ?? false)
-const nextDisabled = computed(() => analysisInProgress.value || (analysisErrorCount.value > 0 && !uploadFilesTax.value?.explanationSubmitted))
+const isUploading = computed(() => uploadFilesTax.value?.isUploading ?? false)
+const isBusy = computed(() => analysisInProgress.value || isUploading.value)
+const hasUnresolvedErrors = computed(
+  () => analysisErrorCount.value > 0 && !uploadFilesTax.value?.explanationSubmitted
+)
+
+const nextDisabled = computed(() => isBusy.value)
+
+const nextLabel = computed(() => {
+  if (isUploading.value) return t('uploading')
+  if (analysisInProgress.value) return t('analyzing')
+  return undefined
+})
+
+function beforeSubmit(): boolean {
+  if (isBusy.value) return false
+  if (hasUnresolvedErrors.value) {
+    focusBanners()
+    return false
+  }
+  return true
+}
 
 function focusBanners() {
   taxBanners.value?.focus()
@@ -136,6 +157,8 @@ function focusBanners() {
 <i18n>
 {
   "en": {
+    "uploading": "Uploading...",
+    "analyzing": "Analyzing...",
     "errors-count": "{count} error to correct | {count} errors to correct",
     "french": "french",
     "this-year-tax": "{0} income tax notice of {1} or full non-taxation",
@@ -178,6 +201,8 @@ function focusBanners() {
     }
   },
   "fr": {
+    "uploading": "Envoi en cours...",
+    "analyzing": "Analyse en cours...",
     "errors-count": "{count} erreur à corriger | {count} erreurs à corriger",
     "french": "français",
     "this-year-tax": "avis d'impôt {0} sur les revenus de {1} ou de non-imposition complet",

--- a/tenantv3/src/components/tax/lib/TaxFooter.vue
+++ b/tenantv3/src/components/tax/lib/TaxFooter.vue
@@ -5,8 +5,8 @@
       <span class="desktop">{{ t('profilefooter.back') }}</span>
     </RouterLink>
     <form @submit.prevent="submit">
-      <DfButton ref="next-btn" primary data-cy="next-btn" :disabled="nextDisabled">{{
-        t('profilefooter.continue')
+      <DfButton ref="next-btn" primary data-cy="next-btn" :aria-disabled="nextDisabled || undefined">{{
+        nextLabel || t('profilefooter.continue')
       }}</DfButton>
     </form>
   </FooterContainer>
@@ -32,6 +32,8 @@ const props = defineProps<{
   step?: TaxStep
   explanation?: string
   nextDisabled?: boolean
+  nextLabel?: string
+  beforeSubmit?: () => boolean
 }>()
 
 const { t } = useI18n()
@@ -63,6 +65,9 @@ async function save(category: TaxCategory, step?: TaxStep) {
 }
 
 const submit = async () => {
+  if (props.beforeSubmit && !props.beforeSubmit()) {
+    return
+  }
   AnalyticsService.validateFunnelStep(stateCategory)
   const saveOk = props.category ? await save(props.category, props.step) : true
   if (saveOk) {
@@ -77,5 +82,10 @@ const submit = async () => {
   justify-content: space-around;
   align-items: center;
   gap: 1rem;
+}
+
+.tax-footer :deep(button[aria-disabled='true']) {
+  opacity: 0.5;
+  cursor: default;
 }
 </style>

--- a/tenantv3/src/components/tax/lib/UploadFilesTax.vue
+++ b/tenantv3/src/components/tax/lib/UploadFilesTax.vue
@@ -52,27 +52,32 @@
       {{ t('explain-situation') }}
     </button>
     <div v-if="showExplainForm" class="explain-form">
-      <div class="fr-input-group">
+      <div class="fr-input-group" :class="{ 'fr-input-group--error': showExplainError }">
         <label for="explainText" class="fr-label">{{ t('explain-question') }}</label>
         <textarea
           id="explainText"
           ref="explainTextarea"
           v-model="explainText"
           class="fr-input"
+          :class="{ 'fr-input--error': showExplainError }"
           rows="5"
           :placeholder="t('explain-placeholder')"
+          aria-describedby="explainText-error"
         />
+        <p
+          v-if="showExplainError"
+          id="explainText-error"
+          aria-live="assertive"
+          class="fr-error-text"
+        >
+          {{ t('explain-error') }}
+        </p>
       </div>
       <p class="fr-info-text">
         {{ t('explain-info') }}
       </p>
       <div class="explain-form-actions">
-        <button
-          type="button"
-          class="fr-btn fr-btn--tertiary fr-btn--sm"
-          :disabled="!explainText.trim()"
-          @click="saveExplanation"
-        >
+        <button type="button" class="fr-btn fr-btn--tertiary fr-btn--sm" @click="saveExplanation">
           {{ t('explain-save') }}
         </button>
       </div>
@@ -147,6 +152,7 @@ const showModale = ref(false)
 const showExplainForm = ref(false)
 const explainText = ref('')
 const explanationSubmitted = ref(false)
+const showExplainError = ref(false)
 
 const store = useTenantStore()
 const taxState = useTaxState()
@@ -159,6 +165,7 @@ const taxDocument = taxState.document
 const documentStatus = computed(() => taxDocument.value?.documentStatus)
 const analysisFailedRules = ref<DocumentRule[]>(taxDocument.value?.documentAnalysisReport?.failedRules ?? [])
 const analysisInProgress = ref(false)
+const isUploading = computed(() => fileUploadStatus.value === UploadStatus.STATUS_SAVING)
 const pollingInterval = ref<ReturnType<typeof setInterval> | null>(null)
 const pollingTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
 const userInitiatedPolling = ref(false)
@@ -315,11 +322,18 @@ async function openExplainSection(isFromLink: boolean = true) {
     AnalyticsService.document_analysis_show_comment('tax')
   }
   showExplainForm.value = true
+  showExplainError.value = false
   await nextTick()
   explainTextarea.value?.focus()
 }
 
 function saveExplanation() {
+  if (!explainText.value.trim()) {
+    showExplainError.value = true
+    explainTextarea.value?.focus()
+    return
+  }
+  showExplainError.value = false
   const params = {
     documentId: taxDocument.value?.id,
     tenantId: taxState.userId,
@@ -332,7 +346,13 @@ function saveExplanation() {
   })
 }
 
-defineExpose({ analysisFailedRules, explanationSubmitted, analysisInProgress, openExplainSection })
+defineExpose({
+  analysisFailedRules,
+  explanationSubmitted,
+  analysisInProgress,
+  isUploading,
+  openExplainSection
+})
 
 async function remove(file: DfFile, silent = false) {
   AnalyticsService.deleteFile(taxState.category)
@@ -351,6 +371,7 @@ async function remove(file: DfFile, silent = false) {
   analysisInProgress.value = false
   analysisFailedRules.value = []
   showExplainForm.value = false
+  showExplainError.value = false
   explainText.value = ''
   explanationSubmitted.value = false
   startPolling()
@@ -476,6 +497,7 @@ async function remove(file: DfFile, silent = false) {
     "explain-placeholder": "Enter text",
     "explain-info": "This explanation will be sent to our team only. It will not appear in your tenant file.",
     "explain-save": "Save",
+    "explain-error": "Please describe your situation before saving.",
     "save-success": "Your explanation has been saved",
     "avis-detected": "Declarative Situation Notice Detected",
     "avis-text1": "You have provided a declarative statement notice (see document title). This document is not valid. Please replace it with your tax assessment notice.",
@@ -490,6 +512,7 @@ async function remove(file: DfFile, silent = false) {
     "explain-placeholder": "Texte saisi",
     "explain-info": "Cette explication sera transmise à notre équipe uniquement. Elle n'apparaîtra pas dans votre dossier locataire.",
     "explain-save": "Enregistrer",
+    "explain-error": "Veuillez décrire votre situation avant d'enregistrer.",
     "save-success": "Votre explication a bien été enregistrée",
     "avis-detected": "Avis de situation déclarative détecté",
     "avis-text1": "Vous avez fourni un avis de situation déclarative (voir titre du document). Ce document n'est pas valide. Merci de le remplacer par votre avis d'imposition.",


### PR DESCRIPTION
Sur la page d'upload des avis d'imposition, le bouton continuer est maintenant enable.
Il peux être cliqué même s'il y a des champs en erreur -> refocus sur les erreur
Il indique également quand une analyse est en cours -> cliquer dessus n'a aucun effet 

Le bouton enregistrer pour expliquer sa situation est également enable
le clic renvoie vers l'erreur si le champ reste vide