### PR TITLE
Feat: remove save button on analysis explanation and use next button instead

### DIFF
--- a/e2e-tests/cypress/e2e/tenant/tax-analysis.cy.ts
+++ b/e2e-tests/cypress/e2e/tenant/tax-analysis.cy.ts
@@ -45,21 +45,12 @@ describe("tax document analysis", () => {
     cy.get(".explain-link").first().click();
     cy.get("#explainText").should("exist").and("have.focus");
 
-    cy.get(".explain-form-actions")
-      .contains("Enregistrer")
-      .should("not.be.disabled");
-    cy.get(".explain-form-actions").contains("Enregistrer").click();
+    cy.get('[data-cy="next-btn"]').click();
     cy.get(".fr-error-text").should("be.visible");
     cy.get("#explainText").should("have.focus");
+    cy.url().should("include", "avec-avis/francais");
 
     cy.get("#explainText").type("test");
-    cy.get(".fr-error-text").should("be.visible");
-
-    cy.get(".explain-form-actions").contains("Enregistrer").click();
-    cy.get(".fr-error-text").should("not.exist");
-    cy.contains("Votre explication a bien été enregistrée").should(
-      "be.visible",
-    );
 
     cy.get('[data-cy="next-btn"]').click();
     cy.url().should("not.include", "avec-avis/francais");

--- a/e2e-tests/cypress/e2e/tenant/visale-analysis.cy.ts
+++ b/e2e-tests/cypress/e2e/tenant/visale-analysis.cy.ts
@@ -52,21 +52,12 @@ describe("visale certificate analysis", () => {
     cy.get(".explain-link").first().click();
     cy.get("#explainText").should("exist").and("have.focus");
 
-    cy.get(".explain-form-actions")
-      .contains("Enregistrer")
-      .should("not.be.disabled");
-    cy.get(".explain-form-actions").contains("Enregistrer").click();
+    cy.get('[data-cy="next-btn"]').click();
     cy.get(".fr-error-text").should("be.visible");
     cy.get("#explainText").should("have.focus");
+    cy.url().should("include", "info-garant");
 
     cy.get("#explainText").type("test");
-    cy.get(".fr-error-text").should("be.visible");
-
-    cy.get(".explain-form-actions").contains("Enregistrer").click();
-    cy.get(".fr-error-text").should("not.exist");
-    cy.contains("Votre explication a bien été enregistrée").should(
-      "be.visible",
-    );
 
     cy.get('[data-cy="next-btn"]').click();
     cy.url().should("not.include", "info-garant");

--- a/tenantv3/src/components/__tests__/AnalysisWrapper.spec.ts
+++ b/tenantv3/src/components/__tests__/AnalysisWrapper.spec.ts
@@ -279,4 +279,33 @@ describe('analysisWrapper', () => {
 
     expect(mockCommentAnalysis).not.toHaveBeenCalled()
   })
+
+  // This test simulates a user clicking twice on the next button
+  it('does not save twice when called concurrently', async () => {
+    let resolveApi!: () => void
+    mockCommentAnalysis.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveApi = resolve
+      })
+    )
+    const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
+    mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    await wrapper.find('.emit-explain').trigger('click')
+    await flushPromises()
+    await wrapper.find('#explainText').setValue('Mon explication')
+
+    const first = wrapper.vm.saveExplanation()
+    const second = wrapper.vm.saveExplanation()
+
+    resolveApi()
+    await first
+    await second
+    await flushPromises()
+
+    expect(mockCommentAnalysis).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tenantv3/src/components/__tests__/AnalysisWrapper.spec.ts
+++ b/tenantv3/src/components/__tests__/AnalysisWrapper.spec.ts
@@ -43,7 +43,8 @@ vi.mock('@/stores/tenant-store', () => ({
 
 vi.mock('@/components/toast/toastUtils', () => ({
   toast: {
-    success: vi.fn()
+    success: vi.fn(),
+    error: vi.fn()
   }
 }))
 
@@ -235,7 +236,9 @@ describe('analysisWrapper', () => {
 
     const textarea = wrapper.find('#explainText')
     await textarea.setValue('Mon explication')
-    await wrapper.find('.explain-form-actions button').trigger('click')
+
+    expect(wrapper.vm.beforeSubmit()).toBe(true)
+    await wrapper.vm.saveExplanation()
     await flushPromises()
 
     expect(mockCommentAnalysis).toHaveBeenCalledWith({
@@ -246,7 +249,7 @@ describe('analysisWrapper', () => {
     expect(wrapper.vm.explanationSubmitted).toBe(true)
   })
 
-  it('shows error and does not save explanation when empty', async () => {
+  it('blocks submit and shows error when explain form is open but text is empty', async () => {
     const rules = [{ rule: 'R_TAX_YEARS', message: 'Bad year', level: 'ERROR', ruleData: null }]
     mockAnalysisResponse(AnalysisStatus.COMPLETED, rules)
 
@@ -258,10 +261,22 @@ describe('analysisWrapper', () => {
 
     const textarea = wrapper.find('#explainText')
     await textarea.setValue('   ')
-    await wrapper.find('.explain-form-actions button').trigger('click')
+
+    expect(wrapper.vm.beforeSubmit()).toBe(false)
+    await flushPromises()
+    expect(wrapper.find('#explainText-error').exists()).toBe(true)
+    expect(mockCommentAnalysis).not.toHaveBeenCalled()
+  })
+
+  it('skips save when no explain form is shown', async () => {
+    mockAnalysisResponse(AnalysisStatus.NO_ANALYSIS_SCHEDULED)
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    await wrapper.vm.saveExplanation()
     await flushPromises()
 
     expect(mockCommentAnalysis).not.toHaveBeenCalled()
-    expect(wrapper.find('#explainText-error').exists()).toBe(true)
   })
 })

--- a/tenantv3/src/components/analysis/AnalysisWrapper.vue
+++ b/tenantv3/src/components/analysis/AnalysisWrapper.vue
@@ -15,7 +15,7 @@
     @explain="openExplainSection()"
   />
   <slot name="fileUploader" />
-  <div v-if="analysisFailedRules.length > 0" ref="explain-section" class="explain-section">
+  <div v-if="analysisFailedRules.length > 0" class="explain-section">
     <div class="separator">
       <div class="separator-line"></div>
       <span class="separator-text">{{ t('or') }}</span>
@@ -94,13 +94,7 @@ const showExplainError = ref(false)
 const explainText = ref('')
 const explainTextarea = useTemplateRef<HTMLTextAreaElement>('explainTextarea')
 const explanationSubmitted = ref(false)
-
-const hasUnresolvedErrors = computed(
-  () =>
-    analysisErrorCount.value > 0 &&
-    !explanationSubmitted.value &&
-    !(showExplainForm.value && explainText.value.trim())
-)
+const isSaving = ref(false)
 
 const analysisErrorCount = computed(() => analysisFailedRules.value?.length ?? 0)
 const isBusy = computed(() => analysisInProgress.value || props.isUploading)
@@ -232,9 +226,11 @@ async function openExplainSection(isFromLink: boolean = true) {
 }
 
 async function saveExplanation() {
+  if (isSaving.value) return
   if (!showExplainForm.value || !explainText.value.trim() || explanationSubmitted.value) {
     return
   }
+  isSaving.value = true
   const params = {
     documentId: document.value?.id,
     tenantId: store.user.id,
@@ -247,6 +243,8 @@ async function saveExplanation() {
   } catch {
     toast.error(t('save-error'), undefined)
     throw new Error('save-failed')
+  } finally {
+    isSaving.value = false
   }
 }
 
@@ -320,7 +318,6 @@ function beforeSubmit(): boolean {
     "explain-placeholder": "Enter text",
     "explain-info": "This explanation will be sent to our team only. It will not appear in your tenant file.",
     "explain-error": "Please describe your situation before continuing.",
-    "save-success": "Your explanation has been saved",
     "save-error": "An error occurred while saving your explanation."
   },
   "fr": {
@@ -333,7 +330,6 @@ function beforeSubmit(): boolean {
     "explain-placeholder": "Texte saisi",
     "explain-info": "Cette explication sera transmise à notre équipe uniquement. Elle n'apparaîtra pas dans votre dossier locataire.",
     "explain-error": "Veuillez décrire votre situation avant de continuer.",
-    "save-success": "Votre explication a bien été enregistrée",
     "save-error": "Erreur lors de l'enregistrement de votre explication."
   }
 }

--- a/tenantv3/src/components/analysis/AnalysisWrapper.vue
+++ b/tenantv3/src/components/analysis/AnalysisWrapper.vue
@@ -48,15 +48,6 @@
       <p id="explainText-info" class="fr-info-text">
         {{ t('explain-info') }}
       </p>
-      <div class="explain-form-actions">
-        <DsfrButton
-          type="button"
-          tertiary
-          size="sm"
-          :label="t('explain-save')"
-          @click="saveExplanation"
-        />
-      </div>
     </div>
   </div>
 </template>
@@ -105,7 +96,10 @@ const explainTextarea = useTemplateRef<HTMLTextAreaElement>('explainTextarea')
 const explanationSubmitted = ref(false)
 
 const hasUnresolvedErrors = computed(
-  () => analysisErrorCount.value > 0 && !explanationSubmitted.value
+  () =>
+    analysisErrorCount.value > 0 &&
+    !explanationSubmitted.value &&
+    !(showExplainForm.value && explainText.value.trim())
 )
 
 const analysisErrorCount = computed(() => analysisFailedRules.value?.length ?? 0)
@@ -127,7 +121,8 @@ defineExpose({
   explanationSubmitted,
   nextDisabled,
   nextLabel,
-  beforeSubmit
+  beforeSubmit,
+  saveExplanation
 })
 
 function focusBanners() {
@@ -236,33 +231,36 @@ async function openExplainSection(isFromLink: boolean = true) {
   explainTextarea.value?.focus()
 }
 
-function saveExplanation() {
-  if (!explainText.value.trim()) {
-    showExplainError.value = true
-    explainTextarea.value?.focus()
+async function saveExplanation() {
+  if (!showExplainForm.value || !explainText.value.trim() || explanationSubmitted.value) {
     return
   }
-  showExplainError.value = false
   const params = {
     documentId: document.value?.id,
     tenantId: store.user.id,
     comment: explainText.value
   }
   AnalyticsService.document_analysis_save_comment(document.value?.documentCategory ?? 'NULL')
-  store
-    .commentAnalysis(params)
-    .then(() => {
-      explanationSubmitted.value = true
-      toast.success(t('save-success'), undefined)
-    })
-    .catch(() => {
-      toast.error(t('save-error'), undefined)
-    })
+  try {
+    await store.commentAnalysis(params)
+    explanationSubmitted.value = true
+  } catch {
+    toast.error(t('save-error'), undefined)
+    throw new Error('save-failed')
+  }
 }
 
 function beforeSubmit(): boolean {
   if (isBusy.value) return false
-  if (hasUnresolvedErrors.value) {
+  if (analysisErrorCount.value > 0 && !explanationSubmitted.value) {
+    if (showExplainForm.value && explainText.value.trim()) {
+      return true
+    }
+    if (showExplainForm.value && !explainText.value.trim()) {
+      showExplainError.value = true
+      explainTextarea.value?.focus()
+      return false
+    }
     focusBanners()
     return false
   }
@@ -321,8 +319,7 @@ function beforeSubmit(): boolean {
     "explain-question": "What difficulty are you encountering to correct this error?",
     "explain-placeholder": "Enter text",
     "explain-info": "This explanation will be sent to our team only. It will not appear in your tenant file.",
-    "explain-save": "Save",
-    "explain-error": "Please describe your situation before saving.",
+    "explain-error": "Please describe your situation before continuing.",
     "save-success": "Your explanation has been saved",
     "save-error": "An error occurred while saving your explanation."
   },
@@ -335,8 +332,7 @@ function beforeSubmit(): boolean {
     "explain-question": "Quelle difficulté rencontrez-vous pour corriger cette erreur ?",
     "explain-placeholder": "Texte saisi",
     "explain-info": "Cette explication sera transmise à notre équipe uniquement. Elle n'apparaîtra pas dans votre dossier locataire.",
-    "explain-save": "Enregistrer",
-    "explain-error": "Veuillez décrire votre situation avant d'enregistrer.",
+    "explain-error": "Veuillez décrire votre situation avant de continuer.",
     "save-success": "Votre explication a bien été enregistrée",
     "save-error": "Erreur lors de l'enregistrement de votre explication."
   }

--- a/tenantv3/src/components/common/GuarantorBadge.vue
+++ b/tenantv3/src/components/common/GuarantorBadge.vue
@@ -1,5 +1,5 @@
 <template>
-  <DsfrBadge :label="t('guarantor-file')" class="guarantor-badge fr-mb-1w" no-icon small />
+  <DsfrBadge :label="t('guarantor-file')" class="guarantor-badge fr-mb-1w" no-icon />
 </template>
 
 <script setup lang="ts">
@@ -11,8 +11,8 @@ const { t } = useI18n()
 
 <style scoped>
 .guarantor-badge {
-  color: #755348;
-  background: #fddfd8;
+  color: #755348 !important;
+  background-color: #fddfd8 !important;
 }
 </style>
 

--- a/tenantv3/src/components/documents/organismGuarantor/OrganismCert.vue
+++ b/tenantv3/src/components/documents/organismGuarantor/OrganismCert.vue
@@ -221,7 +221,8 @@ function documentTypes() {
   })
 }
 
-function submit() {
+async function submit() {
+  await analysisWrapper.value?.saveExplanation()
   props.nextStep?.()
 }
 </script>

--- a/tenantv3/src/components/tax/FrenchTaxForm.vue
+++ b/tenantv3/src/components/tax/FrenchTaxForm.vue
@@ -104,6 +104,7 @@ const isUploading = computed(() => uploadFileTaxWithAnalysis.value?.isUploading 
 const analysisInProgress = computed(() => analysisWrapper.value?.analysisInProgress ?? false)
 
 async function submit() {
+  await analysisWrapper.value?.saveExplanation()
   AnalyticsService.validateFunnelStep(stateCategory)
   await router.push(nextStep)
 }

--- a/tenantv3/src/components/validateStep/AnalysisPreview.vue
+++ b/tenantv3/src/components/validateStep/AnalysisPreview.vue
@@ -1,7 +1,7 @@
 <template>
   <NakedCard class="fr-mt-3w">
     <DsfrBadge v-if="isTenant" class="fr-mb-1w" type="new" :label="t('badge-loc')" no-icon />
-    <DsfrBadge v-else class="fr-mb-1w" type="warning" :label="t('badge-guarantor')" no-icon />
+    <GuarantorBadge v-else />
     <h1 class="fr-h6">
       {{ nameToDisplay }}
     </h1>
@@ -26,6 +26,7 @@ import { useI18n } from 'vue-i18n'
 import DocumentPreviewCard from './DocumentPreviewCard.vue'
 import { useTenantStore } from '@/stores/tenant-store'
 import { DsfrBadge } from '@gouvminint/vue-dsfr'
+import GuarantorBadge from '@/components/common/GuarantorBadge.vue'
 
 const props = defineProps<{
   user: User | Guarantor


### PR DESCRIPTION
Le bouton peu lisible "Enregistrer" est supprimé, l'explication suite à une analyse doc ia est maintenant sauvegardée au clic sur "Continuer"