### PR TITLE
feat : replace asdir modal with error toast

### DIFF
--- a/e2e-tests/cypress/e2e/tenant/tax-analysis.cy.ts
+++ b/e2e-tests/cypress/e2e/tenant/tax-analysis.cy.ts
@@ -95,7 +95,7 @@ describe("tax document analysis", () => {
     cy.get(".analysis-banners").should("not.have.focus");
   });
 
-  it("shows error modal when uploading an avis de situation déclarative", () => {
+  it("shows error toast when uploading an avis de situation déclarative", () => {
     cy.tenantLoginWithFC(user.username, user.password);
     cy.rejectCookies();
 
@@ -116,6 +116,14 @@ describe("tax document analysis", () => {
       "assets/Avis_situation_declarative_titres_seuls.pdf",
     );
 
-    cy.contains("Avis de situation déclarative détecté").should("be.visible");
+    cy.get(".fr-alert--error")
+      .should("be.visible")
+      .and(
+        "contain",
+        "L'avis de situation déclarative n'est pas accepté",
+      );
+
+    // The rejected file must not remain in the upload list
+    cy.get('ul[role="list"]').should("not.exist");
   });
 });

--- a/tenantv3/src/components/__tests__/UploadFileWithAnalysis.spec.ts
+++ b/tenantv3/src/components/__tests__/UploadFileWithAnalysis.spec.ts
@@ -120,16 +120,7 @@ describe('UploadFileWithAnalysis', () => {
     expect(wrapper.vm.isUploading).toBe(false)
   })
 
-  it('forceUploadPendingFiles returns true when nothing to upload', async () => {
-    const wrapper = mountComponent()
-
-    const result = await wrapper.vm.forceUploadPendingFiles()
-
-    expect(result).toBe(true)
-    expect(mockSaveTenantTax).not.toHaveBeenCalled()
-  })
-
-  it('does not upload immediately when beforeSave returns false, then uploads on force', async () => {
+  it('reverts pending files when beforeSave returns false', async () => {
     const beforeSave = vi.fn().mockResolvedValue(false)
     const wrapper = mountComponent({ beforeSave })
     const file = new File(['content'], 'new-tax.pdf', { type: 'application/pdf' })
@@ -139,12 +130,7 @@ describe('UploadFileWithAnalysis', () => {
 
     expect(beforeSave).toHaveBeenCalledOnce()
     expect(mockSaveTenantTax).not.toHaveBeenCalled()
-
-    const result = await wrapper.vm.forceUploadPendingFiles()
-    await flushPromises()
-
-    expect(result).toBe(true)
-    expect(mockSaveTenantTax).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.$.setupState.files).toEqual([])
   })
 
   it('fails upload when maxFileCount is exceeded', async () => {

--- a/tenantv3/src/components/analysis/UploadFileWithAnalysis.vue
+++ b/tenantv3/src/components/analysis/UploadFileWithAnalysis.vue
@@ -89,13 +89,8 @@ const documentWatermarkUrl = computed(() => currentDocument.value?.name)
 
 const isUploading = computed(() => fileUploadStatus.value === UploadStatus.STATUS_SAVING)
 
-async function forceUploadPendingFiles(): Promise<boolean> {
-  return save()
-}
-
 defineExpose({
-  isUploading,
-  forceUploadPendingFiles
+  isUploading
 })
 
 const currentFiles = computed(() => {
@@ -132,9 +127,13 @@ async function addFiles(fileList: File[]) {
   const nf = Array.from(fileList).map((f) => {
     return { name: f.name, file: f, size: f.size }
   })
+  const previousCount = files.value.length
   files.value = [...files.value, ...nf]
   const canContinue = (await props.beforeSave?.(fileList)) ?? true
-  if (!canContinue) return
+  if (!canContinue) {
+    files.value = files.value.slice(0, previousCount)
+    return
+  }
   save()
 }
 

--- a/tenantv3/src/components/tax/FrenchTaxForm.vue
+++ b/tenantv3/src/components/tax/FrenchTaxForm.vue
@@ -146,11 +146,6 @@ async function submit() {
 <i18n lang="json">
 {
   "en": {
-    "avis-detected": "Declarative Situation Notice Detected",
-    "avis-text1": "You have provided a declarative statement notice (see document title). This document is not valid. Please replace it with your tax assessment notice.",
-    "avis-btn": "Submit a valid document",
-    "avis-link-to-doc": "Need help ? Check our documentation",
-    "errors-count": "{count} error to correct | {count} errors to correct",
     "french": "french",
     "this-year-tax": "{0} income tax notice of {1} or full non-taxation",
     "warning": "Warning:",
@@ -192,11 +187,6 @@ async function submit() {
     }
   },
   "fr": {
-    "avis-detected": "Avis de situation déclarative détecté",
-    "avis-text1": "Vous avez fourni un avis de situation déclarative (voir titre du document). Ce document n'est pas valide. Merci de le remplacer par votre avis d'imposition.",
-    "avis-btn": "Déposer votre avis d'imposition",
-    "avis-link-to-doc": "Besoin d'aide ? Consultez notre aide en ligne",
-    "errors-count": "{count} erreur à corriger | {count} erreurs à corriger",
     "french": "français",
     "this-year-tax": "avis d'impôt {0} sur les revenus de {1} ou de non-imposition complet",
     "warning": "Attention :",

--- a/tenantv3/src/components/tax/lib/UploadFileTaxWithAnalysis.vue
+++ b/tenantv3/src/components/tax/lib/UploadFileTaxWithAnalysis.vue
@@ -7,45 +7,21 @@
     :max-file-count="5"
     :analysis-in-progress="analysisInProgress"
     :before-save="canContinue"
-  >
-    <template #custom>
-      <DsfrModalPatch
-        v-model:is-opened="isModalOpened"
-        :title="t('avis-detected')"
-        icon="ri:alarm-warning-line"
-        :actions="modalActions"
-      >
-        <p>
-          {{ t('avis-text1') }}
-        </p>
-        <p>
-          <a
-            href="https://aide.dossierfacile.logement.gouv.fr/fr/article/5-avis-dimposition-eg82wt/"
-            :title="`${t('avis-link-to-doc')} - ${t('new-window')}`"
-            rel="noopener"
-            target="_blank"
-            >{{ t('avis-link-to-doc') }}</a
-          >
-        </p>
-      </DsfrModalPatch>
-    </template>
-  </UploadFileWithAnalysis>
+  />
 </template>
 
 <script setup lang="ts">
+import { toast } from '@/components/toast/toastUtils'
 import type { DocumentSubCategory } from '@/components/documents/share/DocumentTypeConstants'
+import { AnalyticsService } from '@/services/AnalyticsService'
 import { PdfAnalysisService } from '@/services/PdfAnalysisService'
-import type { DsfrButtonProps } from '@gouvminint/vue-dsfr'
-import DsfrModalPatch from 'df-shared-next/src/components/patches/DsfrModalPatch.vue'
 import type { DocumentCategoryStep } from 'df-shared-next/src/models/DfDocument'
-import { computed, ref, useTemplateRef, type ComputedRef } from 'vue'
+import { useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UploadFileWithAnalysis from '../../analysis/UploadFileWithAnalysis.vue'
 
-const isModalOpened = ref(false)
 type UploadFileWithAnalysisRef = {
   isUploading?: boolean
-  forceUploadPendingFiles?: () => Promise<boolean>
 }
 
 const uploadFileWithAnalysis = useTemplateRef<UploadFileWithAnalysisRef>(
@@ -54,7 +30,6 @@ const uploadFileWithAnalysis = useTemplateRef<UploadFileWithAnalysisRef>(
 
 export type UploadFileTaxWithAnalysisExposed = {
   isUploading: boolean
-  forceUploadPendingFiles: () => Promise<boolean>
 }
 
 withDefaults(
@@ -70,51 +45,28 @@ withDefaults(
 defineExpose<UploadFileTaxWithAnalysisExposed>({
   get isUploading() {
     return uploadFileWithAnalysis.value?.isUploading ?? false
-  },
-  async forceUploadPendingFiles() {
-    return (await uploadFileWithAnalysis.value?.forceUploadPendingFiles?.()) ?? false
   }
 })
 
+const { t } = useI18n()
+
 async function canContinue(fileList: File[]): Promise<boolean> {
   if (await PdfAnalysisService.includesRejectedTaxDocuments(fileList)) {
-    isModalOpened.value = true
+    toast.error(t('asdir-error'), document.getElementById('file'))
+    AnalyticsService.asdirDetected()
     return false
   }
   return true
 }
-
-const modalActions: ComputedRef<DsfrButtonProps[]> = computed(() => [
-  {
-    label: t('avis-btn'),
-    type: 'button',
-    onClick() {
-      void forceUploadAfterOverride()
-    }
-  }
-])
-
-async function forceUploadAfterOverride() {
-  isModalOpened.value = false
-  await uploadFileWithAnalysis.value?.forceUploadPendingFiles?.()
-}
-
-const { t } = useI18n()
 </script>
 
 <i18n lang="json">
 {
   "en": {
-    "avis-detected": "Declarative Situation Notice Detected",
-    "avis-text1": "You have provided a declarative statement notice (see document title). This document is not valid. Please replace it with your tax assessment notice.",
-    "avis-btn": "Submit a valid document",
-    "avis-link-to-doc": "Need help ? Check our documentation"
+    "asdir-error": "The declarative situation notice is not accepted. Please upload your tax notice."
   },
   "fr": {
-    "avis-detected": "Avis de situation déclarative détecté",
-    "avis-text1": "Vous avez fourni un avis de situation déclarative (voir titre du document). Ce document n'est pas valide. Merci de le remplacer par votre avis d'imposition.",
-    "avis-btn": "Déposer votre avis d'imposition",
-    "avis-link-to-doc": "Besoin d'aide ? Consultez notre aide en ligne"
+    "asdir-error": "L'avis de situation déclarative n'est pas accepté. Merci de déposer votre avis d'impôt."
   }
 }
 </i18n>

--- a/tenantv3/src/services/AnalyticsService.ts
+++ b/tenantv3/src/services/AnalyticsService.ts
@@ -193,12 +193,8 @@ export const AnalyticsService = {
     sendEvent('funnel', 'force-missing-residency-document')
   },
 
-  avisDetected() {
-    sendEvent('funnel', 'avis-detected')
-  },
-
-  avisForceUpload() {
-    sendEvent('funnel', 'avis-upload-forced')
+  asdirDetected() {
+    sendFullEvent('funnel', 'print', 'document_analysis_show_asdir_error')
   },
 
   validateFunnel() {

--- a/tenantv3/src/services/PdfAnalysisService.ts
+++ b/tenantv3/src/services/PdfAnalysisService.ts
@@ -1,5 +1,3 @@
-import { AnalyticsService } from './AnalyticsService'
-
 export const PdfAnalysisService = {
   async readPdfFirstPage(file: File): Promise<string> {
     try {
@@ -37,15 +35,7 @@ export const PdfAnalysisService = {
     const timeout = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
     try {
       return await Promise.race([
-        Promise.any(
-          files.map(async (file) => {
-            const isRejected = await this.isRejectedAsTaxDocument(file)
-            if (isRejected) {
-              AnalyticsService.avisDetected()
-            }
-            return isRejected
-          })
-        ),
+        Promise.any(files.map((file) => this.isRejectedAsTaxDocument(file))),
         timeout(2000).then(() => false)
       ])
     } catch (error) {


### PR DESCRIPTION
- remplacement de la modale par un toast pour les avis francais, empèche l'upload du fichier concerné et pas de capacité de contournement.
- Note : la modale reste cependant présente pour les avis étrangers et "autre situation". 
TODO : nettoyer mais hors scope pour un déploiement rapide