### PR TITLE
fix: add asdir message in upload section

### DIFF
--- a/tenantv3/src/components/analysis/UploadFileWithAnalysis.vue
+++ b/tenantv3/src/components/analysis/UploadFileWithAnalysis.vue
@@ -32,6 +32,7 @@
     ref="file-upload"
     :current-status="fileUploadStatus"
     :page="4"
+    :error-message="errorMessage"
     @add-files="addFiles"
   ></FileUpload>
   <slot name="custom" />
@@ -64,13 +65,15 @@ const props = withDefaults(
     analysisInProgress?: boolean
     explanation?: string
     beforeSave?: (files: File[]) => Promise<boolean> | boolean
+    errorMessage?: string
   }>(),
   {
     analysisInProgress: false,
     maxFileCount: 5,
     step: undefined,
     explanation: undefined,
-    beforeSave: undefined
+    beforeSave: undefined,
+    errorMessage: undefined
   }
 )
 

--- a/tenantv3/src/components/tax/lib/UploadFileTaxWithAnalysis.vue
+++ b/tenantv3/src/components/tax/lib/UploadFileTaxWithAnalysis.vue
@@ -7,6 +7,7 @@
     :max-file-count="5"
     :analysis-in-progress="analysisInProgress"
     :before-save="canContinue"
+    :error-message="errorMessage"
   />
 </template>
 
@@ -16,7 +17,7 @@ import type { DocumentSubCategory } from '@/components/documents/share/DocumentT
 import { AnalyticsService } from '@/services/AnalyticsService'
 import { PdfAnalysisService } from '@/services/PdfAnalysisService'
 import type { DocumentCategoryStep } from 'df-shared-next/src/models/DfDocument'
-import { useTemplateRef } from 'vue'
+import { ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import UploadFileWithAnalysis from '../../analysis/UploadFileWithAnalysis.vue'
 
@@ -50,10 +51,15 @@ defineExpose<UploadFileTaxWithAnalysisExposed>({
 
 const { t } = useI18n()
 
+const errorMessage = ref<string | undefined>()
+
 async function canContinue(fileList: File[]): Promise<boolean> {
+  // Clear previous inline error on every new attempt
+  errorMessage.value = undefined
   if (await PdfAnalysisService.includesRejectedTaxDocuments(fileList)) {
     toast.error(t('asdir-error'), document.getElementById('file'))
     AnalyticsService.asdirDetected()
+    errorMessage.value = t('asdir-error')
     return false
   }
   return true

--- a/tenantv3/src/components/tax/lib/UploadFilesTax.vue
+++ b/tenantv3/src/components/tax/lib/UploadFilesTax.vue
@@ -25,6 +25,7 @@
     ref="file-upload"
     :current-status="fileUploadStatus"
     :page="4"
+    :error-message="errorMessage"
     @add-files="addFiles"
   ></FileUpload>
   <DsfrModalPatch
@@ -84,6 +85,7 @@ const MAX_FILE_COUNT = 5
 
 const fileUploadStatus = ref(UploadStatus.STATUS_INITIAL)
 const files = ref<{ name: string; file: File; size: number; id?: string; path?: string }[]>([])
+const errorMessage = ref<string | undefined>()
 
 const isModalOpened = ref(false)
 const modalActions: ComputedRef<DsfrButtonProps[]> = computed(() => [
@@ -173,13 +175,18 @@ async function save(): Promise<boolean> {
 }
 
 async function addFiles(fileList: File[]) {
+  // Clear previous inline error on every new attempt
+  errorMessage.value = undefined
   AnalyticsService.uploadFile(taxState.category, props.category)
   const nf = Array.from(fileList).map((f) => {
     return { name: f.name, file: f, size: f.size }
   })
+  const previousCount = files.value.length
   files.value = [...files.value, ...nf]
   if (await PdfAnalysisService.includesRejectedTaxDocuments(fileList)) {
     isModalOpened.value = true
+    errorMessage.value = t('asdir-error')
+    files.value = files.value.slice(0, previousCount)
     return
   }
   save()
@@ -286,6 +293,7 @@ ul {
 {
   "en": {
     "analysis-in-progress": "Analyzing documents. This usually takes less than 10 seconds.",
+    "asdir-error": "The declarative situation notice is not accepted. Please upload your tax notice.",
     "avis-detected": "Declarative Situation Notice Detected",
     "avis-text1": "You have provided a declarative statement notice (see document title). This document is not valid. Please replace it with your tax assessment notice.",
     "avis-btn": "Submit a valid document",
@@ -293,6 +301,7 @@ ul {
   },
   "fr": {
     "analysis-in-progress": "Analyse des documents. Cela prend généralement moins de 10 secondes.",
+    "asdir-error": "L'avis de situation déclarative n'est pas accepté. Merci de déposer votre avis d'impôt.",
     "avis-detected": "Avis de situation déclarative détecté",
     "avis-text1": "Vous avez fourni un avis de situation déclarative (voir titre du document). Ce document n'est pas valide. Merci de le remplacer par votre avis d'imposition.",
     "avis-btn": "Déposer votre avis d'imposition",

--- a/tenantv3/src/components/uploads/FileUpload.vue
+++ b/tenantv3/src/components/uploads/FileUpload.vue
@@ -29,6 +29,9 @@
               {{ t('fileupload.browse') }}
             </label>
           </p>
+          <p v-if="errorMessage" class="fr-error-text fr-mb-0" role="alert">
+            {{ errorMessage }}
+          </p>
         </div>
       </div>
     </form>
@@ -50,11 +53,17 @@ const inputFile = useTemplateRef('inputFile')
 defineExpose({ inputFile })
 
 const props = withDefaults(
-  defineProps<{ currentStatus?: number; page?: number; size?: number }>(),
+  defineProps<{
+    currentStatus?: number
+    page?: number
+    size?: number
+    errorMessage?: string
+  }>(),
   {
     currentStatus: UploadStatus.STATUS_INITIAL,
     page: 0,
-    size: 10
+    size: 10,
+    errorMessage: undefined
   }
 )
 


### PR DESCRIPTION
- ajout du message d'erreur dans la zone d'upload
- même avec la modale asdir, le fichier n'est plus dans la zone d'upload
<img width="880" height="357" alt="image (5)" src="https://github.com/user-attachments/assets/335d8ebf-5027-42cd-9d51-1a2fc3cb1ee3" />