### PR TITLE
fix: co-tenant email not sent to API when names already saved

### DIFF
--- a/tenantv3/src/components/CoupleInformation.vue
+++ b/tenantv3/src/components/CoupleInformation.vue
@@ -80,6 +80,7 @@
               placeholder="nom@exemple.fr"
               type="email"
               :disabled="disableEmailField"
+              @input="handleInput"
             />
           </Field>
           <ErrorMessage v-if="hasSubmited" v-slot="{ message }" name="email">

--- a/tenantv3/src/components/__tests__/CoupleInformation.spec.ts
+++ b/tenantv3/src/components/__tests__/CoupleInformation.spec.ts
@@ -30,6 +30,9 @@ vi.mock('@/stores/tenant-store', () => ({
   })
 }))
 
+// TextField stub intentionally omits 'input' from emits so that the parent's
+// @input listener falls through to the root <input> via Vue 3 attribute
+// fallthrough — matching the real TextField's behavior.
 const stubs = {
   NakedCard: { template: '<div><slot /></div>' },
   TextField: {
@@ -73,7 +76,7 @@ describe('CoupleInformation', () => {
     }
   })
 
-  it('syncs coTenant to model when names are filled then email is typed', async () => {
+  it('includes email in model when filling the form from scratch', async () => {
     const wrapper = mount(CoupleInformation, {
       props: { hasSubmited: false, modelValue: [] },
       global: { stubs }
@@ -98,22 +101,18 @@ describe('CoupleInformation', () => {
     expect(afterEmail[0].email).toBe('marie@example.com')
   })
 
-  it('syncs email for returning user with pre-filled disabled names', async () => {
-    const existingPartner = {
-      id: 42,
-      firstName: 'Marie',
-      lastName: 'Dupont',
-      email: '',
-      guarantors: []
-    }
-
+  it('includes email in model when adding it to an existing co-tenant', async () => {
+    // Simulate a returning user whose co-tenant already has names saved.
+    // onMounted will load the partner into the local coTenant ref and disable
+    // the name fields. The coTenants model (bound to the parent) is a separate
+    // object — only handleInput() unifies them.
     mockUser.value = {
       id: 1,
       email: 'main@example.com',
       apartmentSharing: {
         tenants: [
           { id: 1, email: 'main@example.com', guarantors: [] },
-          existingPartner
+          { id: 42, firstName: 'Marie', lastName: 'Dupont', email: '', guarantors: [] }
         ]
       }
     }
@@ -124,12 +123,10 @@ describe('CoupleInformation', () => {
     })
     await flushPromises()
 
-    // Name fields should be disabled (pre-filled from store)
     const [lastNameInput, firstNameInput] = wrapper.findAll('input').slice(0, 2)
     expect(lastNameInput.element.disabled).toBe(true)
     expect(firstNameInput.element.disabled).toBe(true)
 
-    // Type email — this is the bug scenario: names already saved, email is the only editable field
     const emailInput = wrapper.find('#email')
     await emailInput.setValue('marie@example.com')
 

--- a/tenantv3/src/components/__tests__/CoupleInformation.spec.ts
+++ b/tenantv3/src/components/__tests__/CoupleInformation.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import CoupleInformation from '../CoupleInformation.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+  createI18n: () => ({ global: { t: (key: string) => key } })
+}))
+
+vi.mock('@gouvminint/vue-dsfr', () => ({
+  DsfrButton: { template: '<button><slot /></button>' }
+}))
+
+const { mockUser } = vi.hoisted(() => {
+  const { ref } = require('vue')
+  return {
+    mockUser: ref({
+      id: 1,
+      email: 'main@example.com',
+      apartmentSharing: { tenants: [] as any[] }
+    })
+  }
+})
+
+vi.mock('@/stores/tenant-store', () => ({
+  useTenantStore: () => ({
+    get user() { return mockUser.value },
+    spouseAuthorize: false
+  })
+}))
+
+const stubs = {
+  NakedCard: { template: '<div><slot /></div>' },
+  TextField: {
+    template: '<input :value="modelValue" :disabled="disabled" @input="onInput" />',
+    props: ['modelValue', 'fieldLabel', 'name', 'validationRules', 'disabled'],
+    emits: ['update:modelValue', 'input'],
+    methods: {
+      onInput(e: InputEvent) {
+        this.$emit('update:modelValue', (e.target as HTMLInputElement).value)
+        this.$emit('input', e)
+      }
+    }
+  },
+  FieldLabel: { template: '<label><slot /></label>' },
+  CoupleInformationHelp: { template: '<div />' },
+  DsfrModalPatch: { template: '<div />' },
+  Field: {
+    template: '<div><slot :field="fieldBindings" :meta="{ valid: true }" /></div>',
+    props: ['modelValue', 'name', 'rules', 'type', 'value'],
+    emits: ['update:modelValue'],
+    computed: {
+      fieldBindings() {
+        const self = this as any
+        return {
+          value: self.modelValue,
+          onInput(e: InputEvent) {
+            self.$emit('update:modelValue', (e.target as HTMLInputElement).value)
+          }
+        }
+      }
+    }
+  },
+  ErrorMessage: { template: '<span />' }
+}
+
+describe('CoupleInformation', () => {
+  beforeEach(() => {
+    mockUser.value = {
+      id: 1,
+      email: 'main@example.com',
+      apartmentSharing: { tenants: [] as any[] }
+    }
+  })
+
+  it('syncs coTenant to model when names are filled then email is typed', async () => {
+    const wrapper = mount(CoupleInformation, {
+      props: { hasSubmited: false, modelValue: [] },
+      global: { stubs }
+    })
+
+    const [lastNameInput, firstNameInput] = wrapper.findAll('input').slice(0, 2)
+    const emailInput = wrapper.find('#email')
+
+    await lastNameInput.setValue('Dupont')
+    await firstNameInput.setValue('Marie')
+
+    let emitted = wrapper.emitted('update:modelValue')!
+    expect(emitted.length).toBeGreaterThan(0)
+    const afterNames = emitted[emitted.length - 1][0] as any[]
+    expect(afterNames[0].lastName).toBe('Dupont')
+    expect(afterNames[0].firstName).toBe('Marie')
+
+    await emailInput.setValue('marie@example.com')
+
+    emitted = wrapper.emitted('update:modelValue')!
+    const afterEmail = emitted[emitted.length - 1][0] as any[]
+    expect(afterEmail[0].email).toBe('marie@example.com')
+  })
+
+  it('syncs email for returning user with pre-filled disabled names', async () => {
+    const existingPartner = {
+      id: 42,
+      firstName: 'Marie',
+      lastName: 'Dupont',
+      email: '',
+      guarantors: []
+    }
+
+    mockUser.value = {
+      id: 1,
+      email: 'main@example.com',
+      apartmentSharing: {
+        tenants: [
+          { id: 1, email: 'main@example.com', guarantors: [] },
+          existingPartner
+        ]
+      }
+    }
+
+    const wrapper = mount(CoupleInformation, {
+      props: { hasSubmited: false, modelValue: [] },
+      global: { stubs }
+    })
+    await flushPromises()
+
+    // Name fields should be disabled (pre-filled from store)
+    const [lastNameInput, firstNameInput] = wrapper.findAll('input').slice(0, 2)
+    expect(lastNameInput.element.disabled).toBe(true)
+    expect(firstNameInput.element.disabled).toBe(true)
+
+    // Type email — this is the bug scenario: names already saved, email is the only editable field
+    const emailInput = wrapper.find('#email')
+    await emailInput.setValue('marie@example.com')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    const lastEmit = emitted![emitted!.length - 1][0] as any[]
+    expect(lastEmit[0].email).toBe('marie@example.com')
+    expect(lastEmit[0].firstName).toBe('Marie')
+    expect(lastEmit[0].lastName).toBe('Dupont')
+  })
+})

--- a/tenantv3/src/components/__tests__/CoupleInformation.spec.ts
+++ b/tenantv3/src/components/__tests__/CoupleInformation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import CoupleInformation from '../CoupleInformation.vue'
+import type { CoTenant } from 'df-shared-next/src/models/CoTenant'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
@@ -17,7 +18,7 @@ const { mockUser } = vi.hoisted(() => {
     mockUser: ref({
       id: 1,
       email: 'main@example.com',
-      apartmentSharing: { tenants: [] as any[] }
+      apartmentSharing: { tenants: [] as CoTenant[] }
     })
   }
 })
@@ -34,11 +35,10 @@ const stubs = {
   TextField: {
     template: '<input :value="modelValue" :disabled="disabled" @input="onInput" />',
     props: ['modelValue', 'fieldLabel', 'name', 'validationRules', 'disabled'],
-    emits: ['update:modelValue', 'input'],
+    emits: ['update:modelValue'],
     methods: {
       onInput(e: InputEvent) {
         this.$emit('update:modelValue', (e.target as HTMLInputElement).value)
-        this.$emit('input', e)
       }
     }
   },
@@ -69,7 +69,7 @@ describe('CoupleInformation', () => {
     mockUser.value = {
       id: 1,
       email: 'main@example.com',
-      apartmentSharing: { tenants: [] as any[] }
+      apartmentSharing: { tenants: [] as CoTenant[] }
     }
   })
 
@@ -87,14 +87,14 @@ describe('CoupleInformation', () => {
 
     let emitted = wrapper.emitted('update:modelValue')!
     expect(emitted.length).toBeGreaterThan(0)
-    const afterNames = emitted[emitted.length - 1][0] as any[]
+    const afterNames = emitted[emitted.length - 1][0] as CoTenant[]
     expect(afterNames[0].lastName).toBe('Dupont')
     expect(afterNames[0].firstName).toBe('Marie')
 
     await emailInput.setValue('marie@example.com')
 
     emitted = wrapper.emitted('update:modelValue')!
-    const afterEmail = emitted[emitted.length - 1][0] as any[]
+    const afterEmail = emitted[emitted.length - 1][0] as CoTenant[]
     expect(afterEmail[0].email).toBe('marie@example.com')
   })
 
@@ -135,7 +135,7 @@ describe('CoupleInformation', () => {
 
     const emitted = wrapper.emitted('update:modelValue')
     expect(emitted).toBeTruthy()
-    const lastEmit = emitted![emitted!.length - 1][0] as any[]
+    const lastEmit = emitted![emitted!.length - 1][0] as CoTenant[]
     expect(lastEmit[0].email).toBe('marie@example.com')
     expect(lastEmit[0].firstName).toBe('Marie')
     expect(lastEmit[0].lastName).toBe('Dupont')


### PR DESCRIPTION
## Issue

(Actually encountered on https://www.dossierfacile.logement.gouv.fr/)

When a user returns to the couple form with a co-tenant whose names are already saved, the name fields are disabled. The email input was the only editable field but never called `handleInput()`, so the email was never synced to the `coTenants` model sent to `POST /api/register/application/v2`. The partner invitation email was silently never sent.

## Fix

Add `@input="handleInput"` to the email input field in `CoupleInformation.vue` so the co-tenant email is included in the API payload.

## Root cause

`handleInput()` unifies the local `coTenant` ref with the parent `coTenants` model (`coTenants.value = [coTenant.value]`). It was only bound to the name fields' `@input`. In the fresh flow this works by accident (shared object reference after names are typed), but for returning users with pre-filled disabled names, `handleInput` never fires and the two objects stay separate — so any email typed is lost.