### PR TITLE
fix: doc-ia analysis hidden on salary file update

### DIFF
--- a/tenantv3/src/components/__tests__/UploadFileFinancialWithAnalysis.spec.ts
+++ b/tenantv3/src/components/__tests__/UploadFileFinancialWithAnalysis.spec.ts
@@ -216,4 +216,51 @@ describe('UploadFileFinancialWithAnalysis', () => {
       expect(mockPush).not.toHaveBeenCalled()
     })
   })
+
+  describe('watch on documents – route update on ID change', () => {
+    it('replaces docId in route when store document ID changes', async () => {
+      mockRoute.params = { docId: '791' }
+      mockRoute.path = '/documents-locataire/4/791/travail/salarie/plus-3-mois'
+      mockDocuments.value = [makeDocument({ id: 791 })]
+
+      mountComponent()
+      await flushPromises()
+
+      mockDocuments.value = [makeDocument({ id: 792 })]
+      await flushPromises()
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        '/documents-locataire/4/792/travail/salarie/plus-3-mois'
+      )
+    })
+
+    it('still works for /ajouter/ routes (existing behavior)', async () => {
+      mockRoute.params = { docId: 'ajouter' }
+      mockRoute.path = '/documents-locataire/4/ajouter/travail/salarie/plus-3-mois'
+
+      mountComponent()
+      await flushPromises()
+
+      mockDocuments.value = [makeDocument({ id: 100 })]
+      await flushPromises()
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        '/documents-locataire/4/100/travail/salarie/plus-3-mois'
+      )
+    })
+
+    it('does nothing when docId matches the store document', async () => {
+      mockRoute.params = { docId: '42' }
+      mockRoute.path = '/documents-locataire/4/42/travail/salarie/plus-3-mois'
+      mockDocuments.value = [makeDocument({ id: 42 })]
+
+      mountComponent()
+      await flushPromises()
+
+      mockDocuments.value = [makeDocument({ id: 42, monthlySum: 3000 })]
+      await flushPromises()
+
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/tenantv3/src/components/financial/lib/UploadFileFinancialWithAnalysis.vue
+++ b/tenantv3/src/components/financial/lib/UploadFileFinancialWithAnalysis.vue
@@ -172,7 +172,7 @@ const inputSum = computed({
 watch(
   () => state.documents.value,
   () => {
-    if (!route.path.includes('/ajouter/')) return
+    const currentDocId = Number(route.params.docId)
     const latestMatchingDocument = [...state.documents.value]
       .sort((a, b) => (a.id || 0) - (b.id || 0))
       .reverse()
@@ -182,8 +182,15 @@ watch(
           d.documentSubCategory === 'SALARY' &&
           d.documentCategoryStep === 'SALARY_EMPLOYED_MORE_3_MONTHS'
       )
-    if (latestMatchingDocument?.id) {
+
+    if (!latestMatchingDocument?.id) return
+
+    if (route.path.includes('/ajouter/')) {
       router.replace(route.path.replace('ajouter', String(latestMatchingDocument.id)))
+    } else if (currentDocId && currentDocId !== latestMatchingDocument.id) {
+      router.replace(
+        route.path.replace(String(currentDocId), String(latestMatchingDocument.id))
+      )
     }
   },
   { deep: true }


### PR DESCRIPTION
- L'analyse docia n'était pas visible si on supprime le seul/rajoute un nouveau bulletin de paie. C'ets dû à un changement d'id pas watch par le frontend