### PR TITLE
fix: refactor file save logic for salary with analysis

### DIFF
--- a/tenantv3/src/components/__tests__/UploadFileFinancialWithAnalysis.spec.ts
+++ b/tenantv3/src/components/__tests__/UploadFileFinancialWithAnalysis.spec.ts
@@ -8,6 +8,9 @@ type InternalSetup = {
   beforeUploadSave: () => boolean
   submit: () => Promise<void>
   isModalOpened: boolean
+  inputSum: string
+  parsedMonthlySum: number
+  onFileSaved: () => void
 }
 function setup(wrapper: VueWrapper): InternalSetup {
   return (wrapper.vm.$ as unknown as { setupState: InternalSetup }).setupState
@@ -217,35 +220,34 @@ describe('UploadFileFinancialWithAnalysis', () => {
     })
   })
 
-  describe('watch on documents – route update on ID change', () => {
-    it('replaces docId in route when store document ID changes', async () => {
-      mockRoute.params = { docId: '791' }
-      mockRoute.path = '/documents-locataire/4/791/travail/salarie/plus-3-mois'
-      mockDocuments.value = [makeDocument({ id: 791 })]
-
-      mountComponent()
-      await flushPromises()
-
-      mockDocuments.value = [makeDocument({ id: 792 })]
-      await flushPromises()
-
-      expect(mockReplace).toHaveBeenCalledWith(
-        '/documents-locataire/4/792/travail/salarie/plus-3-mois'
-      )
-    })
-
-    it('still works for /ajouter/ routes (existing behavior)', async () => {
+  describe('onFileSaved – route update after upload', () => {
+    it('navigates from /ajouter/ to /{newId}/ after first upload', async () => {
       mockRoute.params = { docId: 'ajouter' }
       mockRoute.path = '/documents-locataire/4/ajouter/travail/salarie/plus-3-mois'
-
-      mountComponent()
-      await flushPromises()
-
       mockDocuments.value = [makeDocument({ id: 100 })]
+
+      const wrapper = mountComponent()
       await flushPromises()
+
+      setup(wrapper).onFileSaved()
 
       expect(mockReplace).toHaveBeenCalledWith(
         '/documents-locataire/4/100/travail/salarie/plus-3-mois'
+      )
+    })
+
+    it('navigates to new doc ID when backend recreated the document', async () => {
+      mockRoute.params = { docId: '791' }
+      mockRoute.path = '/documents-locataire/4/791/travail/salarie/plus-3-mois'
+      mockDocuments.value = [makeDocument({ id: 792 })]
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      setup(wrapper).onFileSaved()
+
+      expect(mockReplace).toHaveBeenCalledWith(
+        '/documents-locataire/4/792/travail/salarie/plus-3-mois'
       )
     })
 
@@ -254,13 +256,59 @@ describe('UploadFileFinancialWithAnalysis', () => {
       mockRoute.path = '/documents-locataire/4/42/travail/salarie/plus-3-mois'
       mockDocuments.value = [makeDocument({ id: 42 })]
 
-      mountComponent()
+      const wrapper = mountComponent()
       await flushPromises()
 
-      mockDocuments.value = [makeDocument({ id: 42, monthlySum: 3000 })]
+      setup(wrapper).onFileSaved()
+
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete last file – sum and document preserved', () => {
+    it('preserves monthlySum after the document disappears from the store', async () => {
+      mockRoute.params = { docId: 'ajouter' }
+      mockRoute.path = '/documents-locataire/4/ajouter/travail/salarie/plus-3-mois'
+      mockDocuments.value = []
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      setup(wrapper).inputSum = '1500'
+      await flushPromises()
+
+      mockDocuments.value = [makeDocument({ id: 100, monthlySum: 1500 })]
+      mockRoute.params = { docId: '100' }
+      mockRoute.path = '/documents-locataire/4/100/travail/salarie/plus-3-mois'
+      await flushPromises()
+
+      mockDocuments.value = []
+      await flushPromises()
+
+      expect(setup(wrapper).parsedMonthlySum).toBe(1500)
+      expect(setup(wrapper).beforeUploadSave()).toBe(true)
+    })
+
+    it('does not switch to an older document when current document is deleted', async () => {
+      mockRoute.params = { docId: '823' }
+      mockRoute.path = '/documents-locataire/4/823/travail/salarie/plus-3-mois'
+      mockDocuments.value = [
+        makeDocument({ id: 821, monthlySum: 222 }),
+        makeDocument({ id: 823, monthlySum: 555 })
+      ]
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      setup(wrapper).inputSum = '555'
+      await flushPromises()
+      mockReplace.mockClear()
+
+      mockDocuments.value = [makeDocument({ id: 821, monthlySum: 222 })]
       await flushPromises()
 
       expect(mockReplace).not.toHaveBeenCalled()
+      expect(setup(wrapper).parsedMonthlySum).toBe(555)
     })
   })
 })

--- a/tenantv3/src/components/analysis/UploadFileWithAnalysis.vue
+++ b/tenantv3/src/components/analysis/UploadFileWithAnalysis.vue
@@ -56,6 +56,8 @@ import { useDocumentFormKey } from '../documents/documentFormState'
 import { type DocumentSubCategory } from '../documents/share/DocumentTypeConstants'
 import { toast } from '../toast/toastUtils'
 
+const emit = defineEmits<{ saved: [] }>()
+
 const props = withDefaults(
   defineProps<{
     docCategory: DocumentCategory
@@ -180,6 +182,7 @@ async function save(): Promise<boolean> {
       files.value = []
       fileUploadStatus.value = UploadStatus.STATUS_INITIAL
       toast.success(t('file-saved'), fileUpload.value?.inputFile)
+      emit('saved')
       return true
     })
     .catch((err) => {

--- a/tenantv3/src/components/financial/lib/UploadFileFinancialWithAnalysis.vue
+++ b/tenantv3/src/components/financial/lib/UploadFileFinancialWithAnalysis.vue
@@ -31,6 +31,7 @@
         :max-file-count="10"
         :analysis-in-progress="analysisWrapper?.analysisInProgress ?? false"
         :before-save="beforeUploadSave"
+        @saved="onFileSaved"
       />
     </template>
   </AnalysisWrapper>
@@ -67,7 +68,7 @@ import { useTenantStore } from '@/stores/tenant-store'
 import type { DsfrButtonProps } from '@gouvminint/vue-dsfr'
 import DsfrModalPatch from 'df-shared-next/src/components/patches/DsfrModalPatch.vue'
 import { DfDocument } from 'df-shared-next/src/models/DfDocument'
-import { computed, provide, ref, useTemplateRef, watch, type ComputedRef } from 'vue'
+import { computed, provide, ref, useTemplateRef, type ComputedRef } from 'vue'
 import { useForm } from 'vee-validate'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -163,33 +164,27 @@ const inputSum = computed({
   }
 })
 
-watch(
-  () => state.documents.value,
-  () => {
-    const currentDocId = Number(route.params.docId)
-    const latestMatchingDocument = [...state.documents.value]
-      .sort((a, b) => (a.id || 0) - (b.id || 0))
-      .reverse()
-      .find(
-        (d) =>
-          d.documentCategory === 'FINANCIAL' &&
-          d.documentSubCategory === 'SALARY' &&
-          d.documentCategoryStep === 'SALARY_EMPLOYED_MORE_3_MONTHS'
-      )
+function onFileSaved() {
+  const currentDocId = Number(route.params.docId)
+  if (state.documents.value.some((d) => d.id === currentDocId)) return
 
-    if (!latestMatchingDocument?.id) return
+  const latestDoc = [...state.documents.value]
+    .filter(
+      (d) =>
+        d.documentCategory === 'FINANCIAL' &&
+        d.documentSubCategory === 'SALARY' &&
+        d.documentCategoryStep === 'SALARY_EMPLOYED_MORE_3_MONTHS'
+    )
+    .sort((a, b) => (b.id || 0) - (a.id || 0))[0]
 
-    if (route.path.includes('/ajouter/')) {
-      router.replace(route.path.replace('ajouter', String(latestMatchingDocument.id)))
-    } else if (currentDocId && currentDocId !== latestMatchingDocument.id) {
-      router.replace(
-        route.path.replace(String(currentDocId), String(latestMatchingDocument.id))
-      )
-    }
-  },
-  { deep: true }
-)
+  if (!latestDoc?.id) return
 
+  if (route.path.includes('/ajouter/')) {
+    router.replace(route.path.replace('ajouter', String(latestDoc.id)))
+  } else if (currentDocId) {
+    router.replace(route.path.replace(String(currentDocId), String(latestDoc.id)))
+  }
+}
 
 function validateSum(input: string) {
   if (!input) return 'field-required'


### PR DESCRIPTION
- remplace le watch générique par `onFileSaved` pour discrimier le cas de 2 activités salariés lors de la suppression du dernier fichier 