### PR TITLE
fix(tenant): remove FranceConnect logout after tenant deletion

### DIFF
--- a/tenantv3/src/stores/tenant-store.ts
+++ b/tenantv3/src/stores/tenant-store.ts
@@ -371,12 +371,10 @@ export const useTenantStore = defineStore('tenant', {
       this.initState()
     },
     async deleteAccount() {
-      const isFC = this.user.franceConnect
       await AuthService.deleteAccount()
       this.logoutCommit()
       this.initState()
-      const url = isFC ? 'https://fcp.integ01.dev-franceconnect.fr/api/v1/logout' : MAIN_URL
-      window.location.replace(url)
+      window.location.replace(MAIN_URL)
     },
     async loadUser() {
       const response = await AuthService.loadUser()


### PR DESCRIPTION
The code currently uses the deprecated FranceConnect v1 endpoint. The v2 endpoint cannot be called directly from the frontend and requires a more complex implementation. For this reason, we have decided not to implement FranceConnect logout after tenant deletion.