### PR TITLE
fix: a11y pre-audit

### DIFF
--- a/df-shared-next/src/components/TextAreaWithCounter.vue
+++ b/df-shared-next/src/components/TextAreaWithCounter.vue
@@ -5,7 +5,7 @@
         {{ t('label') }}
       </slot>
         (<span v-if="isRequired">{{ t('required') }}</span>
-        <span v-else-if="!isRequired"">{{ t('optional') }}</span>)
+        <span v-else>{{ t('optional') }}</span>)
       </label>
     <textarea
       :id="textAreaID"

--- a/df-shared-next/src/components/TextAreaWithCounter.vue
+++ b/df-shared-next/src/components/TextAreaWithCounter.vue
@@ -1,37 +1,52 @@
 <template>
-  <textarea
-    ref="textareaEl"
-    v-bind="$attrs"
-    v-model="model"
-    :maxlength="max"
-    :aria-describedby="describedBy"
-    class="fr-input"
-  />
-  <p :id="counterId" class="fr-my-1w">
-    {{ t('character-count', { n: model.length, max }) }}
-  </p>
+  <div class="fr-input-group fr-mt-2w">
+    <label class="fr-label" :for="textAreaID">
+        <slot name="label">
+        {{ t('label') }}
+      </slot>
+        (<span v-if="isRequired">{{ t('required') }}</span>
+        <span v-else-if="!isRequired"">{{ t('optional') }}</span>)
+      </label>
+    <textarea
+      :id="textAreaID"
+      ref="textareaEl"
+      v-bind="$attrs"
+      v-model="model"
+      :maxlength="max"
+      :aria-describedby="describedBy"
+      :required="isRequired"
+      class="fr-input"
+    />
+    <p :id="counterId" class="fr-my-1w">
+      {{ t('character-count', { n: model.length, max }) }}
+    </p>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRandomId } from '@gouvminint/vue-dsfr'
 
 defineOptions({ inheritAttrs: false })
 
-const props = defineProps<{
-  max: number
+interface Props {
+    max: number
   counterId: string
   extraAriaDescribedBy?: string
-}>()
+  id?: string
+  isRequired?: boolean
+}
+
+const {max, counterId, extraAriaDescribedBy, id, isRequired = false} = defineProps<Props>()
 
 const model = defineModel<string>({ required: true })
 const textareaEl = useTemplateRef<HTMLTextAreaElement>('textareaEl')
 const { t } = useI18n()
+const textAreaID = id ?? useRandomId()
 
 const describedBy = computed(() =>
-  props.extraAriaDescribedBy
-    ? `${props.counterId} ${props.extraAriaDescribedBy}`
-    : props.counterId
+  extraAriaDescribedBy ? `${counterId} ${extraAriaDescribedBy}` : counterId
 )
 
 defineExpose({
@@ -44,9 +59,15 @@ defineExpose({
 <i18n lang="json">
 {
   "en": {
+    "label": "Situation explanation",
+    "required": "required",
+    "optional": "optional",
     "character-count": "{n}/{max} characters"
   },
   "fr": {
+    "label": "Explication de la situation",
+    "required": "obligatoire",
+    "optional": "facultatif",
     "character-count": "{n}/{max} caractères"
   }
 }

--- a/df-shared-next/src/components/form/FieldLabel.vue
+++ b/df-shared-next/src/components/form/FieldLabel.vue
@@ -23,7 +23,7 @@ withDefaults(
 const { t } = useI18n()
 </script>
 
-<i18n>
+<i18n lang="json">
 {
   "en": {
     "required" : "required",

--- a/tenantv3/src/components/documents/legalPersonGuarantor/RepresentativeIdentification.vue
+++ b/tenantv3/src/components/documents/legalPersonGuarantor/RepresentativeIdentification.vue
@@ -12,9 +12,9 @@
           }"
         >
           <div class="fr-input-group">
-            <h1 class="fr-label fr-text--regular" for="firstName">
-              {{ t('representativeidentification.organism-name') }} :
-            </h1>
+            <FieldLabel :required="true" for-input="firstName">{{
+              t('representativeidentification.organism-name')
+            }}</FieldLabel>
             <input
               v-bind="field"
               id="firstName"
@@ -36,13 +36,13 @@
       </NakedCard>
       <NakedCard class="fr-mt-3w fr-p-md-5w">
         <div class="fr-select-group">
-          <label class="fr-label" for="select">
-            <b>
-              J’ajoute une pièce d’identité en cours de validité. Attention, veillez à ajouter votre
-              pièce recto-verso !
-            </b>
-          </label>
-          <select id="selectID" v-model="identificationDocument" class="fr-select fr-mb-3w">
+          <FieldLabel :required="true" for-input="selectID">{{ t('identity-doc') }}</FieldLabel>
+          <select
+            id="selectID"
+            v-model="identificationDocument"
+            class="fr-select fr-mb-3w"
+            required
+          >
             <option v-if="!identificationDocument" selected disabled></option>
             <option v-for="d in documents" :key="d.key" :value="d">
               {{ t(d.key) }}
@@ -55,7 +55,7 @@
             :document="guarantorIdentificationDocument"
             :document-denied-reasons="guarantorIdentificationDocument?.documentDeniedReasons"
             :document-status="documentStatus"
-          ></AllDeclinedMessages>
+          />
           <div v-if="listFiles().length > 0" class="fr-col-md-12 fr-mb-3w">
             <ListItem
               v-for="file in listFiles()"
@@ -71,11 +71,11 @@
               ref="file-upload"
               :current-status="fileUploadStatus"
               @add-files="addFiles"
-            ></FileUpload>
+            />
           </div>
         </div>
       </NakedCard>
-      <GuarantorFooter @on-back="goBack"></GuarantorFooter>
+      <GuarantorFooter @on-back="goBack" />
     </Form>
   </div>
 </template>
@@ -103,6 +103,7 @@ import FileUpload from '../../uploads/FileUpload.vue'
 import ListItem from '../../uploads/ListItem.vue'
 import AllDeclinedMessages from '../share/AllDeclinedMessages.vue'
 import { DocumentTypeConstants } from '../share/DocumentTypeConstants'
+import FieldLabel from 'df-shared-next/src/components/form/FieldLabel.vue'
 
 const { t } = useI18n()
 const { handleValidationNavigation } = useHandleValidationNavigation()
@@ -285,3 +286,14 @@ td {
   border: 1px solid #ececec;
 }
 </style>
+
+<i18n lang="json">
+{
+  "en": {
+    "identity-doc": "Attach a valid form of identification. Please be sure to attach both the front and back of your ID"
+  },
+  "fr": {
+    "identity-doc": "J’ajoute une pièce d’identité en cours de validité. Attention: veillez à ajouter votre pièce recto-verso"
+  }
+}
+</i18n>

--- a/tenantv3/src/components/financial/lib/UploadFileFinancialWithAnalysis.vue
+++ b/tenantv3/src/components/financial/lib/UploadFileFinancialWithAnalysis.vue
@@ -10,6 +10,7 @@
       class="fr-input fr-mb-2w"
       required
       autocomplete="off"
+      inputmode="numeric"
       data-cy="monthlySum"
       aria-describedby="monthlySum-desc"
       @blur="AnalyticsService.writeText(state.category)"

--- a/tenantv3/src/components/financial/lib/UploadFilesFinancial.vue
+++ b/tenantv3/src/components/financial/lib/UploadFilesFinancial.vue
@@ -10,6 +10,7 @@
       class="fr-input fr-mb-2w"
       required
       autocomplete="off"
+      inputmode="numeric"
       data-cy="monthlySum"
       aria-describedby="monthlySum-desc"
       @blur="AnalyticsService.writeText(state.category)"

--- a/tenantv3/src/components/financial/noIncome/NoIncome.vue
+++ b/tenantv3/src/components/financial/noIncome/NoIncome.vue
@@ -1,13 +1,13 @@
 <template>
   <BackLinkRow :label="t('no-income')" :to="parent" category="pas-de-revenus" />
-  <label for="explanation" class="fr-mb-1w">{{ t('can-add-explanation') }}</label>
   <TextAreaWithCounter
-    id="explanation"
     ref="custom-text"
     v-model="customText"
     :max="1000"
     counter-id="no-income-explanation-counter"
-  />
+  >
+    <template #label>{{ t('can-add-explanation') }}</template>
+  </TextAreaWithCounter>
   <FinancialFooter :on-submit="save" />
 </template>
 

--- a/tenantv3/src/components/guarantorResidency/GuarantorOther.vue
+++ b/tenantv3/src/components/guarantorResidency/GuarantorOther.vue
@@ -33,7 +33,7 @@
       name="customText"
       :max="2000"
       rows="3"
-      required
+      :is-required="true"
       counter-id="guarantor-customtext-counter"
     />
     <span v-if="errorMessage" role="alert" class="fr-error-text">{{ t(errorMessage || '') }}</span>
@@ -93,7 +93,7 @@ async function submit() {
 }
 </script>
 
-<i18n>
+<i18n lang="json">
 {
   "en": {
     "guarantor-other": "Other",
@@ -101,11 +101,11 @@ async function submit() {
     "advice": "If you don't have one, please add an affidavit explaining your situation. You can use the model available on the {0} website.",
     "no-doc": "You cannot provide a document",
     "tenant": {
-      "please-provide" : "Please provide {0} attesting to your guarantor's housing situation.",
+      "please-provide": "Please provide {0} attesting to your guarantor's housing situation.",
       "no-doc-long": "You don't have proof of your guarantor's accommodation status? Please explain the reasons in the text field and add a sworn statement."
     },
     "couple": {
-      "please-provide" : "Please provide {0} attesting to their guarantor's housing situation.",
+      "please-provide": "Please provide {0} attesting to their guarantor's housing situation.",
       "no-doc-long": "You don't have proof of the accommodation status of your spouse's guarantor? Please explain the reasons in the text field and add a sworn statement."
     }
   },
@@ -115,11 +115,11 @@ async function submit() {
     "advice": "Si vous n'en avez pas, veuillez ajouter une attestation sur l’honneur expliquant sa situation. Vous pouvez utiliser le modèle disponible sur le site {0}",
     "no-doc": "Vous ne pouvez pas fournir de document",
     "tenant": {
-      "please-provide" : "Veuillez fournir {0} attestant la situation d’hébergement de votre garant.",
+      "please-provide": "Veuillez fournir {0} attestant la situation d’hébergement de votre garant.",
       "no-doc-long": "Vous n’avez pas de document attestant la situation d’hébergement de votre garant ? Veuillez en expliquer les raisons dans le champ texte et ajouter une attestation sur l’honneur."
     },
     "couple": {
-      "please-provide" : "Veuillez fournir {0} attestant la situation d’hébergement de son garant.",
+      "please-provide": "Veuillez fournir {0} attestant la situation d’hébergement de son garant.",
       "no-doc-long": "Vous n’avez pas de document attestant la situation d’hébergement du garant de votre conjoint ? Veuillez en expliquer les raisons dans le champ texte et ajouter une attestation sur l’honneur."
     }
   }

--- a/tenantv3/src/components/tax/OtherSituationTaxForm.vue
+++ b/tenantv3/src/components/tax/OtherSituationTaxForm.vue
@@ -6,18 +6,17 @@
   <p>{{ t('this-situation') }}</p>
 
   <form class="honor-declaration-form">
-    <div class="fr-input-group">
-      <label :for="formId" class="fr-label"
-        >{{ t(textKey + '.describe-situation') }} ({{ t('form.label.required') }})
-      </label>
-      <TextAreaWithCounter
-        :id="formId"
-        v-model="explanation"
-        required
-        :max="1355"
-        counter-id="tax-explanation-counter"
-      />
-    </div>
+    <TextAreaWithCounter
+      :id="formId"
+      v-model="explanation"
+      :is-required="true"
+      :max="1355"
+      counter-id="tax-explanation-counter"
+    >
+      <template #label>
+        {{ t(textKey + '.describe-situation') }}
+      </template>
+    </TextAreaWithCounter>
   </form>
 
   <p>{{ t(textKey + '.you-can-add-docs') }}</p>

--- a/tenantv3/src/components/validateStep/AnalysisFinalForm.vue
+++ b/tenantv3/src/components/validateStep/AnalysisFinalForm.vue
@@ -6,6 +6,7 @@
         <p>{{ t('description') }}</p>
         <div class="fr-input-group" :class="{ 'fr-input-group--error': !isMessageValid }">
           <TextAreaWithCounter
+            id="message"
             v-model="message"
             name="message"
             rows="1"

--- a/tenantv3/src/components/validateStep/AnalysisFinalForm.vue
+++ b/tenantv3/src/components/validateStep/AnalysisFinalForm.vue
@@ -5,16 +5,16 @@
         <h1 class="fr-h6">{{ t('title') }}</h1>
         <p>{{ t('description') }}</p>
         <div class="fr-input-group" :class="{ 'fr-input-group--error': !isMessageValid }">
-          <label for="message" class="fr-label">{{ t('label') }}</label>
           <TextAreaWithCounter
-            id="message"
             v-model="message"
             name="message"
             rows="1"
             :max="2000"
             counter-id="message-desc"
             extra-aria-described-by="message-error"
-          />
+          >
+            <template #label>{{ t('label') }}</template>
+          </TextAreaWithCounter>
           <p
             v-if="!isMessageValid && showError"
             id="message-error"
@@ -156,7 +156,7 @@ const submit = () => {
 {
   "en": {
     "title": "Message for the owner",
-    "label": "Your message (optional)",
+    "label": "Your message",
     "description": "You can add a message for your future landlords. It will be displayed at the beginning of your file.",
     "honor-declaration": "I declare on my honor the accuracy of these informations (Article 441-1 of the Penal Code: 3 years imprisonment and €45,000 fine).",
     "consent-declaration": "I declare that I have obtained the consent of the persons mentioned in my file (spouse, roommates, guarantors).",
@@ -167,7 +167,7 @@ const submit = () => {
   },
   "fr": {
     "title": "Message pour le propriétaire",
-    "label": "Votre message (facultatif)",
+    "label": "Votre message",
     "description": "Vous pouvez ajouter un message à destination de vos futurs propriétaires. Il sera affiché au début de votre dossier.",
     "honor-declaration": "Je déclare avoir pris connaissance de l'article 441-1 du code pénal qui punit le faux et l'usage de faux de trois ans d'emprisonnement et de 45000 euros d'amende.",
     "consent-declaration": "Je déclare avoir obtenu le consentement des personnes mentionnées dans mon dossier (conjoint, colocataires, garants).",


### PR DESCRIPTION
enhanced text-area component
label/input association
translations

> [!WARNING]
> Validation is missing for the id document of the moral guarantor