### PR TITLE
fix(tenant): allow international latin characters in name validation

### DIFF
--- a/e2e-tests/cypress/e2e/tenant/flatmate.cy.ts
+++ b/e2e-tests/cypress/e2e/tenant/flatmate.cy.ts
@@ -55,7 +55,8 @@ describe("flatmate tenant scenario", () => {
     cy.expectPath("/info-garant/0");
     cy.get("#organismName").type("Organisme").uploadDocument().clickOnNext();
 
-    const name = "Personne Morale 123";
+    // Name with international characters: exercises the relaxed onlyAlpha rule
+    const name = "Señora Muñoz-Dvořák";
     cy.get("#firstName").type(name);
     cy.get("#selectID").select("Autre").uploadDocument().clickOnNext();
 

--- a/tenantv3/src/main.ts
+++ b/tenantv3/src/main.ts
@@ -25,7 +25,7 @@ const ENVIRONMENT = import.meta.env.VITE_ENVIRONMENT
 const CRISP_ENABLED = import.meta.env.VITE_CRISP_ENABLED
 
 defineRule('onlyAlpha', (value: string) => {
-  const regex = /^[a-zA-Z \-'’àâäçéèêëîïôöùûüÿæœÀÂÄÇÉÈÊËÎÏÔÖÙÛÜŸÆŒ]*$/
+  const regex = /^[\p{Script=Latin}\p{M} \-'’]*$/u
   if (!regex.test(value)) {
     return 'only-alpha'
   }


### PR DESCRIPTION
## Contexte

La PR #2019 (fix XSS) a ajouté la règle `onlyAlpha` sur le prénom du représentant de personne morale (`RepresentativeIdentification.vue`). Sa whitelist n'acceptait que les lettres accentuées **françaises** :

- des prénoms légitimes comme *Muñoz*, *Søren*, *Łukasz* ou *Dvořák* sont rejetés ;
- le test e2e `flatmate.cy.ts` est rouge en préprod depuis le 07/08 : sa donnée de test « Personne Morale 123 » contient des chiffres, la validation bloque le submit et la navigation vers `/liste-garants` n'a jamais lieu.

## Changements

- **`tenantv3/src/main.ts`** — la règle `onlyAlpha` passe à `/^[\p{Script=Latin}\p{M} \-'’]*$/u` : toutes les lettres latines de toutes les langues + accents combinants (Unicode décomposé). Les chiffres et caractères de balisage restent rejetés (objectif XSS préservé). Le périmètre « script latin » (et non `\p{L}` tous alphabets) est aligné sur la normalisation des noms du backend document-analysis (`NameUtil.sanitizeForComparison`), qui translittère précisément ces lettres (ø→o, ł→l, ß→ss…) mais supprime tout caractère non latin — un prénom en cyrillique donnerait une clé de comparaison vide côté docIA.
- **`e2e-tests/cypress/e2e/tenant/flatmate.cy.ts`** — la donnée de test devient « Señora Muñoz-Dvořák » : débloque la spec et verrouille la nouvelle règle en e2e.

La règle étant globale, les 5 champs qui l'utilisent (IdentityForm, CoupleInformation, GuarantorNameForm, CoTenantName, RepresentativeIdentification) bénéficient de l'élargissement.

## Tests

- Typecheck `tenantv3` OK.
- Regex validée sur échantillon : accepte Jean-Pierre, N'Golo, Chloé, Muñoz, Björn, Dvořák, Erdoğan, São, Søren, Łukasz, Þór ; rejette chiffres, `<script>`, `=`, `@`, alphabets non latins.

À noter : les échecs e2e `alone.cy.ts` / `declined.cy.ts` sont un sujet distinct (wording `COMPLETED` de l'opt-in activé en préprod le 10/08) et seront traités séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)