### PR TITLE
fix(e2e): wait for document analysis before clicking next

### DIFF
--- a/e2e-tests/cypress/support/commands/tenant.ts
+++ b/e2e-tests/cypress/support/commands/tenant.ts
@@ -52,12 +52,6 @@ Cypress.Commands.add("uploadDocument", (numberOfFiles: number = 1) => {
   cy.waitUntilStepIsReady();
 });
 
-// Uploading used to raise the global vue-loading-overlay, which the tests waited on. That overlay
-// was replaced by the in-page analysis progress block, so synchronize on the next button instead.
-// AnalysisFooter marks the button with aria-disabled (not disabled) while the file uploads and
-// while the analysis report is being polled, and clicking it during that time is silently ignored
-// (AnalysisWrapper.beforeSubmit). The app re-enables the button after its 30s polling timeout,
-// so the 40s ceiling can only be hit if the button stays stuck for good.
 Cypress.Commands.add("waitUntilStepIsReady", () => {
   cy.get("body").then(($body) => {
     if ($body.find('[data-cy="next-btn"]').length === 0) {

--- a/e2e-tests/cypress/support/commands/tenant.ts
+++ b/e2e-tests/cypress/support/commands/tenant.ts
@@ -53,16 +53,19 @@ Cypress.Commands.add("uploadDocument", (numberOfFiles: number = 1) => {
 });
 
 // Uploading used to raise the global vue-loading-overlay, which the tests waited on. That overlay
-// was replaced by the in-page analysis progress block, so synchronize on the next button instead:
-// it stays disabled while the file uploads and while the analysis report is being polled.
+// was replaced by the in-page analysis progress block, so synchronize on the next button instead.
+// AnalysisFooter marks the button with aria-disabled (not disabled) while the file uploads and
+// while the analysis report is being polled, and clicking it during that time is silently ignored
+// (AnalysisWrapper.beforeSubmit). The app re-enables the button after its 30s polling timeout,
+// so the 40s ceiling can only be hit if the button stays stuck for good.
 Cypress.Commands.add("waitUntilStepIsReady", () => {
   cy.get("body").then(($body) => {
     if ($body.find('[data-cy="next-btn"]').length === 0) {
       return;
     }
-    cy.get('[data-cy="next-btn"]', { timeout: 40000 }).should(
-      "not.be.disabled",
-    );
+    cy.get('[data-cy="next-btn"]', { timeout: 40000 })
+      .should("not.be.disabled")
+      .and("not.have.attr", "aria-disabled");
   });
 });
 


### PR DESCRIPTION
## Problème

`alone.cy.ts` échoue en preprod depuis le 28/08 (4 des 5 derniers runs nocturnes), bloqué sur l'étape garant propriétaire (`/info-garant/2/.../owner`).

Cause : `waitUntilStepIsReady` (introduit par #2033) vérifie `not.be.disabled`, mais le bouton « Continuer » d'`AnalysisFooter` utilise `aria-disabled` pendant le polling du rapport d'analyse. L'assertion passait donc instantanément, le test cliquait pendant l'analyse, et `AnalysisWrapper.beforeSubmit` avalait le clic silencieusement (`isBusy` → return false). Le test ne réussissait que lorsque la docIA preprod répondait en moins d'une seconde — mesuré à 181 ms sur un run local OK, contre 6 tentatives échouées sur les runs CI où l'analyse était plus lente.

## Correctif

`waitUntilStepIsReady` attend aussi la disparition de `aria-disabled`. Le plafond de 40 s est inchangé et reste borné par le timeout de polling de 30 s de l'app, qui réactive le bouton dans tous les cas — l'assertion ne peut donc échouer que si le bouton reste réellement bloqué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)